### PR TITLE
Add saved account usage enrichment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +167,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "time",
+ "ureq",
  "uuid",
 ]
 
@@ -180,6 +187,35 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -283,6 +319,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +404,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,10 +458,129 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -484,6 +668,18 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "log"
@@ -608,10 +804,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -665,6 +876,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +900,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -787,10 +1047,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -801,6 +1079,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -882,6 +1171,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +1197,68 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -922,6 +1283,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1024,6 +1391,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1147,6 +1523,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1403,6 +1788,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,6 +1851,39 @@ name = "zeroize_derive"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sysinfo = "0.38.4"
 time = { version = "0.3.47", features = ["formatting", "parsing", "serde"] }
+ureq = { version = "3.1.2", features = ["json"] }
 uuid = { version = "1.23.0", features = ["serde", "v4"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ codex-account-switcher
 codex-account-switcher status [--json]
 codex-account-switcher list [--json]
 codex-account-switcher save [--json]
+codex-account-switcher usage [ACCOUNT_ID] [--json]
 codex-account-switcher activate [ACCOUNT_ID] [--force] [--json]
 codex-account-switcher delete [ACCOUNT_ID] [--json]
 ```
@@ -34,8 +35,9 @@ codex-account-switcher delete [ACCOUNT_ID] [--json]
 ## Behavior
 
 - `save` snapshots the currently logged-in Codex account.
-- `list` shows saved accounts for the current environment.
+- `list` shows saved accounts for the current environment and includes weekly usage/reset data when it can read it from the saved snapshot.
 - `status` shows the live account, Codex root, saved-account count, and process warnings.
+- `usage` fetches current usage for the live account or for a saved account by id.
 - `activate` restores a saved snapshot. Reliable swaps require all Codex processes to be closed first; `--force` lets the command attempt activation anyway, but it still fails if the restored files do not stay stable.
 - `delete` removes the saved snapshot from the switcher store only.
 
@@ -110,3 +112,4 @@ cargo fmt --check
 - v1 supports only the existing live-login capture flow. It does not drive Codex login itself.
 - Saved snapshots are keyed by the current environment and current account identity.
 - Plan metadata is best effort and may be blank if the token does not expose a recognizable value.
+- Usage enrichment depends on saved `auth.json` tokens still being present and accepted by the Codex/OpenAI usage endpoints.

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,9 @@ mod tui;
 use uuid::Uuid;
 
 use crate::env::AppEnv;
-use crate::model::{AccountView, DisplayIdentity, RunningCodexProcess, SavedAccountMetadata};
+use crate::model::{
+    AccountUsageView, AccountView, DisplayIdentity, RunningCodexProcess, SavedAccountMetadata,
+};
 use crate::repository::SnapshotRepository;
 
 pub struct App<S> {
@@ -19,7 +21,12 @@ pub enum InteractiveMode {
     DeleteOnce,
 }
 
-fn account_view(account: SavedAccountMetadata, active_id: Option<Uuid>) -> AccountView {
+fn account_view(
+    account: SavedAccountMetadata,
+    active_id: Option<Uuid>,
+    usage: Option<AccountUsageView>,
+    usage_error: Option<String>,
+) -> AccountView {
     AccountView {
         id: account.id,
         email: account.email,
@@ -31,6 +38,8 @@ fn account_view(account: SavedAccountMetadata, active_id: Option<Uuid>) -> Accou
         created_at: account.created_at,
         updated_at: account.updated_at,
         last_activated_at: account.last_activated_at,
+        usage,
+        usage_error,
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -38,7 +38,7 @@ fn account_view(
         created_at: account.created_at,
         updated_at: account.updated_at,
         last_activated_at: account.last_activated_at,
-        usage,
+        usage: usage.or(account.cached_usage),
         usage_error,
     }
 }

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -160,13 +160,19 @@ where
                         self.env.codex_root.display()
                     )
                 })?;
+                let live_snapshot = live.snapshot.clone();
                 let target = usage_target_from_snapshot(
                     self.env.kind.clone(),
                     live.snapshot,
                     UsageSource::LiveAccessToken,
                     true,
                 )?;
-                Ok(fetch_usage(target)?.0)
+                let (output, refreshed_snapshot) = fetch_usage(target)?;
+                if refreshed_snapshot != live_snapshot {
+                    codex::restore_snapshot(&self.env, &refreshed_snapshot, &output.account, false)
+                        .context("refreshed live auth but failed to update local auth files")?;
+                }
+                Ok(output)
             }
         }
     }

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -149,10 +149,6 @@ where
                     account_id,
                     &output.account,
                     &refreshed_snapshot,
-                )?;
-                self.repository.update_cached_usage(
-                    &self.env.kind,
-                    account_id,
                     Some(output.usage.clone()),
                 )?;
                 Ok(output)
@@ -168,7 +164,7 @@ where
                     self.env.kind.clone(),
                     live.snapshot,
                     UsageSource::LiveAccessToken,
-                    false,
+                    true,
                 )?;
                 Ok(fetch_usage(target)?.0)
             }

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -1,13 +1,11 @@
 use anyhow::{Context, Result};
-use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::codex;
 use crate::env::AppEnv;
 use crate::model::{
-    AccountUsageView, ActivateOutput, DeleteOutput, DisplayIdentity, ListOutput,
-    RunningCodexProcess, SaveAction, SaveOutput, SnapshotBlob, StatusOutput, UsageOutput,
-    UsageSource,
+    ActivateOutput, DeleteOutput, DisplayIdentity, ListOutput, RunningCodexProcess, SaveAction,
+    SaveOutput, SnapshotBlob, StatusOutput, UsageOutput, UsageSource,
 };
 use crate::repository::SnapshotRepository;
 use crate::secrets::SecretStore;
@@ -17,12 +15,6 @@ use super::{
     App, account_view, match_saved_account, saved_identity, should_verify_activation_stability,
     subject_bound_identity_matches,
 };
-
-struct AccountUsageStateOwned {
-    usage: Option<AccountUsageView>,
-    usage_error: Option<String>,
-    identity: Option<DisplayIdentity>,
-}
 
 impl<S> App<S>
 where
@@ -56,24 +48,11 @@ where
             .as_ref()
             .and_then(|bundle| match_saved_account(&accounts, &bundle.identity))
             .map(|account| account.id);
-        let usage = self.saved_account_usage(&accounts);
         Ok(ListOutput {
             environment: self.env.kind.clone(),
             accounts: accounts
                 .into_iter()
-                .map(|mut account| {
-                    let state = usage.get(&account.id);
-                    if let Some(identity) = state.and_then(|state| state.identity.as_ref()) {
-                        account.email = identity.email.clone();
-                        account.subject = identity.subject.clone();
-                        account.name = identity.name.clone();
-                        account.plan_label = identity.plan_label.clone();
-                    }
-                    let (usage, usage_error) = state
-                        .map(|state| (state.usage.clone(), state.usage_error.clone()))
-                        .unwrap_or((None, None));
-                    account_view(account, active_id, usage, usage_error)
-                })
+                .map(|account| account_view(account, active_id, None, None))
                 .collect(),
         })
     }
@@ -157,12 +136,12 @@ where
     pub fn usage(&self, account_id: Option<Uuid>) -> Result<UsageOutput> {
         match account_id {
             Some(account_id) => {
-                let (metadata, snapshot) =
-                    self.repository.load_snapshot(&self.env.kind, account_id)?;
+                let (_, snapshot) = self.repository.load_snapshot(&self.env.kind, account_id)?;
                 let target = usage_target_from_snapshot(
                     self.env.kind.clone(),
                     snapshot,
                     UsageSource::SavedAccessToken,
+                    true,
                 )?;
                 let (output, refreshed_snapshot) = fetch_usage(target)?;
                 self.repository.replace_snapshot(
@@ -171,7 +150,11 @@ where
                     &output.account,
                     &refreshed_snapshot,
                 )?;
-                let _ = metadata;
+                self.repository.update_cached_usage(
+                    &self.env.kind,
+                    account_id,
+                    Some(output.usage.clone()),
+                )?;
                 Ok(output)
             }
             None => {
@@ -185,6 +168,7 @@ where
                     self.env.kind.clone(),
                     live.snapshot,
                     UsageSource::LiveAccessToken,
+                    false,
                 )?;
                 Ok(fetch_usage(target)?.0)
             }
@@ -197,57 +181,6 @@ where
         Ok(DeleteOutput {
             deleted_account_id: account_id,
         })
-    }
-
-    fn saved_account_usage(
-        &self,
-        accounts: &[crate::model::SavedAccountMetadata],
-    ) -> HashMap<Uuid, AccountUsageStateOwned> {
-        let mut usage_by_account = HashMap::with_capacity(accounts.len());
-        for account in accounts {
-            let usage = match self.repository.load_snapshot(&self.env.kind, account.id) {
-                Ok((_, snapshot)) => {
-                    match usage_target_from_snapshot(
-                        self.env.kind.clone(),
-                        snapshot,
-                        UsageSource::SavedAccessToken,
-                    ) {
-                        Ok(target) => match fetch_usage(target) {
-                            Ok((output, refreshed_snapshot)) => {
-                                let _ = self.repository.replace_snapshot(
-                                    &self.env.kind,
-                                    account.id,
-                                    &output.account,
-                                    &refreshed_snapshot,
-                                );
-                                AccountUsageStateOwned {
-                                    usage: Some(output.usage),
-                                    usage_error: None,
-                                    identity: Some(output.account),
-                                }
-                            }
-                            Err(error) => AccountUsageStateOwned {
-                                usage: None,
-                                usage_error: Some(format!("{error:#}")),
-                                identity: None,
-                            },
-                        },
-                        Err(error) => AccountUsageStateOwned {
-                            usage: None,
-                            usage_error: Some(format!("{error:#}")),
-                            identity: None,
-                        },
-                    }
-                }
-                Err(error) => AccountUsageStateOwned {
-                    usage: None,
-                    usage_error: Some(format!("{error:#}")),
-                    identity: None,
-                },
-            };
-            usage_by_account.insert(account.id, usage);
-        }
-        usage_by_account
     }
 }
 

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -168,7 +168,9 @@ where
                     true,
                 )?;
                 let (output, refreshed_snapshot) = fetch_usage(target)?;
-                if refreshed_snapshot != live_snapshot {
+                if refreshed_snapshot != live_snapshot
+                    && codex::live_bundle_matches_snapshot(&self.env, &live_snapshot)?
+                {
                     codex::restore_snapshot(&self.env, &refreshed_snapshot, &output.account, false)
                         .context("refreshed live auth but failed to update local auth files")?;
                 }

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -190,10 +190,15 @@ where
 }
 
 fn live_bundle_still_matches_snapshot(env: &AppEnv, snapshot: &SnapshotBlob) -> bool {
-    codex::live_bundle_matches_snapshot(env, snapshot).unwrap_or_else(|_| {
-        std::thread::sleep(Duration::from_millis(25));
-        codex::live_bundle_matches_snapshot(env, snapshot).unwrap_or(false)
-    })
+    for attempt in 0..3 {
+        if codex::live_bundle_matches_snapshot(env, snapshot).unwrap_or(false) {
+            return true;
+        }
+        if attempt < 2 {
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+    false
 }
 
 #[cfg(test)]

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use std::time::Duration;
 use uuid::Uuid;
 
 use crate::codex;
@@ -169,8 +170,7 @@ where
                 )?;
                 let (output, refreshed_snapshot) = fetch_usage(target)?;
                 if refreshed_snapshot != live_snapshot
-                    && codex::live_bundle_matches_snapshot(&self.env, &live_snapshot)
-                        .unwrap_or(false)
+                    && live_bundle_still_matches_snapshot(&self.env, &live_snapshot)
                 {
                     codex::restore_snapshot(&self.env, &refreshed_snapshot, &output.account, false)
                         .context("refreshed live auth but failed to update local auth files")?;
@@ -187,6 +187,13 @@ where
             deleted_account_id: account_id,
         })
     }
+}
+
+fn live_bundle_still_matches_snapshot(env: &AppEnv, snapshot: &SnapshotBlob) -> bool {
+    codex::live_bundle_matches_snapshot(env, snapshot).unwrap_or_else(|_| {
+        std::thread::sleep(Duration::from_millis(25));
+        codex::live_bundle_matches_snapshot(env, snapshot).unwrap_or(false)
+    })
 }
 
 #[cfg(test)]

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -137,7 +137,7 @@ where
     pub fn usage(&self, account_id: Option<Uuid>) -> Result<UsageOutput> {
         match account_id {
             Some(account_id) => {
-                let (_, snapshot) = self.repository.load_snapshot(&self.env.kind, account_id)?;
+                let (snapshot, _, _) = self.load_activation_target(account_id)?;
                 let target = usage_target_from_snapshot(
                     self.env.kind.clone(),
                     snapshot,

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -169,7 +169,8 @@ where
                 )?;
                 let (output, refreshed_snapshot) = fetch_usage(target)?;
                 if refreshed_snapshot != live_snapshot
-                    && codex::live_bundle_matches_snapshot(&self.env, &live_snapshot)?
+                    && codex::live_bundle_matches_snapshot(&self.env, &live_snapshot)
+                        .unwrap_or(false)
                 {
                     codex::restore_snapshot(&self.env, &refreshed_snapshot, &output.account, false)
                         .context("refreshed live auth but failed to update local auth files")?;

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -1,19 +1,28 @@
 use anyhow::{Context, Result};
+use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::codex;
 use crate::env::AppEnv;
 use crate::model::{
-    ActivateOutput, DeleteOutput, DisplayIdentity, ListOutput, RunningCodexProcess, SaveAction,
-    SaveOutput, SnapshotBlob, StatusOutput,
+    AccountUsageView, ActivateOutput, DeleteOutput, DisplayIdentity, ListOutput,
+    RunningCodexProcess, SaveAction, SaveOutput, SnapshotBlob, StatusOutput, UsageOutput,
+    UsageSource,
 };
 use crate::repository::SnapshotRepository;
 use crate::secrets::SecretStore;
+use crate::usage::{fetch_usage, usage_target_from_snapshot};
 
 use super::{
     App, account_view, match_saved_account, saved_identity, should_verify_activation_stability,
     subject_bound_identity_matches,
 };
+
+struct AccountUsageStateOwned {
+    usage: Option<AccountUsageView>,
+    usage_error: Option<String>,
+    identity: Option<DisplayIdentity>,
+}
 
 impl<S> App<S>
 where
@@ -47,11 +56,24 @@ where
             .as_ref()
             .and_then(|bundle| match_saved_account(&accounts, &bundle.identity))
             .map(|account| account.id);
+        let usage = self.saved_account_usage(&accounts);
         Ok(ListOutput {
             environment: self.env.kind.clone(),
             accounts: accounts
                 .into_iter()
-                .map(|account| account_view(account, active_id))
+                .map(|mut account| {
+                    let state = usage.get(&account.id);
+                    if let Some(identity) = state.and_then(|state| state.identity.as_ref()) {
+                        account.email = identity.email.clone();
+                        account.subject = identity.subject.clone();
+                        account.name = identity.name.clone();
+                        account.plan_label = identity.plan_label.clone();
+                    }
+                    let (usage, usage_error) = state
+                        .map(|state| (state.usage.clone(), state.usage_error.clone()))
+                        .unwrap_or((None, None));
+                    account_view(account, active_id, usage, usage_error)
+                })
                 .collect(),
         })
     }
@@ -67,7 +89,7 @@ where
             self.repository
                 .save_snapshot(&self.env.kind, &live.identity, &live.snapshot)?;
         Ok(SaveOutput {
-            account: account_view(metadata.clone(), Some(metadata.id)),
+            account: account_view(metadata.clone(), Some(metadata.id), None, None),
             action: if created {
                 SaveAction::Created
             } else {
@@ -101,7 +123,7 @@ where
             .sync_activated_account(&self.env.kind, account_id, &snapshot_identity)
             .context("activated live auth but failed to update local metadata")?;
         Ok(ActivateOutput {
-            account: account_view(metadata, Some(account_id)),
+            account: account_view(metadata, Some(account_id), None, None),
             warnings,
         })
     }
@@ -132,12 +154,100 @@ where
         crate::process::detect_running_codex_processes()
     }
 
+    pub fn usage(&self, account_id: Option<Uuid>) -> Result<UsageOutput> {
+        match account_id {
+            Some(account_id) => {
+                let (metadata, snapshot) =
+                    self.repository.load_snapshot(&self.env.kind, account_id)?;
+                let target = usage_target_from_snapshot(
+                    self.env.kind.clone(),
+                    snapshot,
+                    UsageSource::SavedAccessToken,
+                )?;
+                let (output, refreshed_snapshot) = fetch_usage(target)?;
+                self.repository.replace_snapshot(
+                    &self.env.kind,
+                    account_id,
+                    &output.account,
+                    &refreshed_snapshot,
+                )?;
+                let _ = metadata;
+                Ok(output)
+            }
+            None => {
+                let live = codex::read_live_auth_bundle(&self.env).with_context(|| {
+                    format!(
+                        "no live Codex auth bundle found at {}",
+                        self.env.codex_root.display()
+                    )
+                })?;
+                let target = usage_target_from_snapshot(
+                    self.env.kind.clone(),
+                    live.snapshot,
+                    UsageSource::LiveAccessToken,
+                )?;
+                Ok(fetch_usage(target)?.0)
+            }
+        }
+    }
+
     pub fn delete(&self, account_id: Uuid) -> Result<DeleteOutput> {
         self.repository
             .delete_snapshot(&self.env.kind, account_id)?;
         Ok(DeleteOutput {
             deleted_account_id: account_id,
         })
+    }
+
+    fn saved_account_usage(
+        &self,
+        accounts: &[crate::model::SavedAccountMetadata],
+    ) -> HashMap<Uuid, AccountUsageStateOwned> {
+        let mut usage_by_account = HashMap::with_capacity(accounts.len());
+        for account in accounts {
+            let usage = match self.repository.load_snapshot(&self.env.kind, account.id) {
+                Ok((_, snapshot)) => {
+                    match usage_target_from_snapshot(
+                        self.env.kind.clone(),
+                        snapshot,
+                        UsageSource::SavedAccessToken,
+                    ) {
+                        Ok(target) => match fetch_usage(target) {
+                            Ok((output, refreshed_snapshot)) => {
+                                let _ = self.repository.replace_snapshot(
+                                    &self.env.kind,
+                                    account.id,
+                                    &output.account,
+                                    &refreshed_snapshot,
+                                );
+                                AccountUsageStateOwned {
+                                    usage: Some(output.usage),
+                                    usage_error: None,
+                                    identity: Some(output.account),
+                                }
+                            }
+                            Err(error) => AccountUsageStateOwned {
+                                usage: None,
+                                usage_error: Some(format!("{error:#}")),
+                                identity: None,
+                            },
+                        },
+                        Err(error) => AccountUsageStateOwned {
+                            usage: None,
+                            usage_error: Some(format!("{error:#}")),
+                            identity: None,
+                        },
+                    }
+                }
+                Err(error) => AccountUsageStateOwned {
+                    usage: None,
+                    usage_error: Some(format!("{error:#}")),
+                    identity: None,
+                },
+            };
+            usage_by_account.insert(account.id, usage);
+        }
+        usage_by_account
     }
 }
 

--- a/src/app/tui.rs
+++ b/src/app/tui.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Error, Result};
 use console::{Key, Term, style};
 use dialoguer::{Select, theme::ColorfulTheme};
+use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::model::{AccountView, ListOutput, RunningCodexProcess, SaveAction, StatusOutput};
@@ -253,8 +254,12 @@ fn render_account_label(account: &AccountView) -> String {
     if let Some(usage) = &account.usage
         && let Some(weekly) = &usage.weekly
     {
-        parts.push(format!("- Weekly Remaining: {}%", weekly.remaining_percent));
-        parts.push(format!("- Reset {}", weekly.reset_at.date()));
+        if weekly.reset_at <= OffsetDateTime::now_utc() {
+            parts.push("- Weekly Reset passed".to_owned());
+        } else {
+            parts.push(format!("- Weekly Remaining: {}%", weekly.remaining_percent));
+            parts.push(format!("- Reset {}", weekly.reset_at.date()));
+        }
     } else if account.usage_error.is_some() {
         parts.push("- Usage unavailable".to_owned());
     }

--- a/src/app/tui.rs
+++ b/src/app/tui.rs
@@ -250,6 +250,14 @@ fn render_account_label(account: &AccountView) -> String {
     } else {
         parts.push(format!("- Saved on {}", account.updated_at.date()));
     }
+    if let Some(usage) = &account.usage
+        && let Some(weekly) = &usage.weekly
+    {
+        parts.push(format!("- Weekly Remaining: {}%", weekly.remaining_percent));
+        parts.push(format!("- Reset {}", weekly.reset_at.date()));
+    } else if account.usage_error.is_some() {
+        parts.push("- Usage unavailable".to_owned());
+    }
     parts.join(" ")
 }
 
@@ -722,6 +730,8 @@ mod tests {
                 created_at: OffsetDateTime::UNIX_EPOCH,
                 updated_at: OffsetDateTime::UNIX_EPOCH,
                 last_activated_at: is_active.then_some(OffsetDateTime::UNIX_EPOCH),
+                usage: None,
+                usage_error: None,
             }],
         }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
+use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::app::{App, InteractiveMode};
@@ -197,11 +198,15 @@ fn render_account_summary(account: &AccountView) -> String {
     if let Some(usage) = &account.usage
         && let Some(weekly) = &usage.weekly
     {
-        line.push_str(&format!(
-            " [weekly remaining: {}%, reset {}]",
-            weekly.remaining_percent,
-            weekly.reset_at.date()
-        ));
+        if weekly.reset_at <= OffsetDateTime::now_utc() {
+            line.push_str(" [weekly reset passed]");
+        } else {
+            line.push_str(&format!(
+                " [weekly remaining: {}%, reset {}]",
+                weekly.remaining_percent,
+                weekly.reset_at.date()
+            ));
+        }
     } else if account.usage_error.is_some() {
         line.push_str(" [usage unavailable]");
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 use crate::app::{App, InteractiveMode};
 use crate::env;
-use crate::model::RunningCodexProcess;
+use crate::model::{AccountUsageView, AccountView, RunningCodexProcess, UsageOutput};
 use crate::process::format_process_table;
 use crate::repository::SnapshotRepository;
 use crate::secrets::MigratingSecretStore;
@@ -31,6 +31,11 @@ enum Command {
         json: bool,
     },
     Save {
+        #[arg(long)]
+        json: bool,
+    },
+    Usage {
+        account_id: Option<Uuid>,
         #[arg(long)]
         json: bool,
     },
@@ -84,12 +89,7 @@ pub fn run() -> Result<()> {
                 println!("No saved accounts in {}.", list.environment);
             } else {
                 for account in list.accounts {
-                    println!(
-                        "{} {}{}",
-                        account.id,
-                        account.email,
-                        if account.is_active { " [active]" } else { "" }
-                    );
+                    println!("{}", render_account_summary(&account));
                 }
             }
             Ok(())
@@ -100,6 +100,15 @@ pub fn run() -> Result<()> {
                 print_json(&output)?;
             } else {
                 println!("Saved {} ({})", output.account.email, output.account.id);
+            }
+            Ok(())
+        }
+        Some(Command::Usage { account_id, json }) => {
+            let output = app.usage(account_id)?;
+            if json {
+                print_json(&output)?;
+            } else {
+                print_usage_output(&output);
             }
             Ok(())
         }
@@ -175,5 +184,58 @@ fn print_process_summary(title: &str, processes: &[RunningCodexProcess]) {
     println!("{title}:");
     for line in format_process_table(processes) {
         println!("{line}");
+    }
+}
+
+fn render_account_summary(account: &AccountView) -> String {
+    let mut line = format!(
+        "{} {}{}",
+        account.id,
+        account.email,
+        if account.is_active { " [active]" } else { "" }
+    );
+    if let Some(usage) = &account.usage
+        && let Some(weekly) = &usage.weekly
+    {
+        line.push_str(&format!(
+            " [weekly remaining: {}%, reset {}]",
+            weekly.remaining_percent,
+            weekly.reset_at.date()
+        ));
+    } else if account.usage_error.is_some() {
+        line.push_str(" [usage unavailable]");
+    }
+    line
+}
+
+fn print_usage_output(output: &UsageOutput) {
+    println!("Environment: {}", output.environment);
+    println!("Account: {}", output.account.email);
+    if let Some(plan) = &output.account.plan_label {
+        println!("Plan: {plan}");
+    }
+    print_usage_summary(&output.usage);
+}
+
+fn print_usage_summary(usage: &AccountUsageView) {
+    println!("Source: {}", format!("{:?}", usage.source).to_lowercase());
+    println!("Fetched at: {}", usage.fetched_at);
+    if let Some(five_hour) = &usage.five_hour {
+        println!(
+            "5h remaining: {}% (reset {})",
+            five_hour.remaining_percent, five_hour.reset_at
+        );
+    }
+    if let Some(weekly) = &usage.weekly {
+        println!(
+            "Weekly remaining: {}% (reset {})",
+            weekly.remaining_percent, weekly.reset_at
+        );
+    }
+    if let Some(credits) = &usage.credits {
+        println!(
+            "Credits: {} (has_credits={}, unlimited={})",
+            credits.balance, credits.has_credits, credits.unlimited
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ pub mod model;
 pub mod process;
 pub mod repository;
 pub mod secrets;
+pub mod usage;

--- a/src/model.rs
+++ b/src/model.rs
@@ -101,6 +101,8 @@ pub struct SavedAccountMetadata {
     pub created_at: OffsetDateTime,
     pub updated_at: OffsetDateTime,
     pub last_activated_at: Option<OffsetDateTime>,
+    #[serde(default)]
+    pub cached_usage: Option<AccountUsageView>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -111,7 +113,7 @@ pub struct MetadataIndex {
     pub accounts: Vec<SavedAccountMetadata>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AccountView {
     pub id: Uuid,
     pub email: String,
@@ -182,7 +184,7 @@ pub struct DeleteOutput {
     pub deleted_account_id: Uuid,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AccountUsageView {
     pub source: UsageSource,
     pub fetched_at: OffsetDateTime,
@@ -191,21 +193,21 @@ pub struct AccountUsageView {
     pub credits: Option<CreditsView>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UsageWindowView {
     pub used_percent: u8,
     pub remaining_percent: u8,
     pub reset_at: OffsetDateTime,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CreditsView {
     pub has_credits: bool,
     pub unlimited: bool,
     pub balance: String,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum UsageSource {
     LiveAccessToken,

--- a/src/model.rs
+++ b/src/model.rs
@@ -27,13 +27,13 @@ impl std::fmt::Display for EnvironmentKind {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SnapshotBlob {
     pub schema_version: u32,
     pub files: Vec<SnapshotFile>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SnapshotFile {
     pub name: String,
     pub bytes_base64: String,

--- a/src/model.rs
+++ b/src/model.rs
@@ -123,6 +123,8 @@ pub struct AccountView {
     pub created_at: OffsetDateTime,
     pub updated_at: OffsetDateTime,
     pub last_activated_at: Option<OffsetDateTime>,
+    pub usage: Option<AccountUsageView>,
+    pub usage_error: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -139,6 +141,13 @@ pub struct StatusOutput {
 pub struct ListOutput {
     pub environment: EnvironmentKind,
     pub accounts: Vec<AccountView>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct UsageOutput {
+    pub environment: EnvironmentKind,
+    pub account: DisplayIdentity,
+    pub usage: AccountUsageView,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -171,4 +180,36 @@ pub struct RunningCodexProcess {
 #[derive(Clone, Debug, Serialize)]
 pub struct DeleteOutput {
     pub deleted_account_id: Uuid,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct AccountUsageView {
+    pub source: UsageSource,
+    pub fetched_at: OffsetDateTime,
+    pub five_hour: Option<UsageWindowView>,
+    pub weekly: Option<UsageWindowView>,
+    pub credits: Option<CreditsView>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct UsageWindowView {
+    pub used_percent: u8,
+    pub remaining_percent: u8,
+    pub reset_at: OffsetDateTime,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CreditsView {
+    pub has_credits: bool,
+    pub unlimited: bool,
+    pub balance: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageSource {
+    LiveAccessToken,
+    LiveRefreshToken,
+    SavedAccessToken,
+    SavedRefreshToken,
 }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -7,7 +7,9 @@ use anyhow::{Context, Result, anyhow};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
-use crate::model::{DisplayIdentity, EnvironmentKind, SavedAccountMetadata, SnapshotBlob};
+use crate::model::{
+    AccountUsageView, DisplayIdentity, EnvironmentKind, SavedAccountMetadata, SnapshotBlob,
+};
 use crate::secrets::SecretStore;
 use codec::{decode_snapshot, encode_snapshot};
 use index_store::MetadataIndexStore;
@@ -134,6 +136,7 @@ where
         account_id: Uuid,
         identity: &DisplayIdentity,
         snapshot: &SnapshotBlob,
+        usage: Option<AccountUsageView>,
     ) -> Result<SavedAccountMetadata> {
         let mut index = self.index_store.load_index()?;
         let position = index
@@ -147,27 +150,10 @@ where
         account.subject = identity.subject.clone();
         account.name = identity.name.clone();
         account.plan_label = identity.plan_label.clone();
+        account.cached_usage = usage;
         let metadata = account.clone();
         self.secret_store
             .save(&metadata.secret_key, &encoded_snapshot)?;
-        self.index_store.save_index(&index)?;
-        Ok(metadata)
-    }
-
-    pub fn update_cached_usage(
-        &self,
-        environment: &EnvironmentKind,
-        account_id: Uuid,
-        usage: Option<crate::model::AccountUsageView>,
-    ) -> Result<SavedAccountMetadata> {
-        let mut index = self.index_store.load_index()?;
-        let position = index
-            .accounts
-            .iter()
-            .position(|account| account.id == account_id && &account.environment == environment)
-            .ok_or_else(|| anyhow!("saved account {account_id} not found"))?;
-        index.accounts[position].cached_usage = usage;
-        let metadata = index.accounts[position].clone();
         self.index_store.save_index(&index)?;
         Ok(metadata)
     }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -95,6 +95,7 @@ where
                 created_at: now,
                 updated_at: now,
                 last_activated_at: None,
+                cached_usage: None,
             };
             index.accounts.push(metadata.clone());
             (metadata, true)
@@ -146,10 +147,27 @@ where
         account.subject = identity.subject.clone();
         account.name = identity.name.clone();
         account.plan_label = identity.plan_label.clone();
-        account.updated_at = OffsetDateTime::now_utc();
         let metadata = account.clone();
         self.secret_store
             .save(&metadata.secret_key, &encoded_snapshot)?;
+        self.index_store.save_index(&index)?;
+        Ok(metadata)
+    }
+
+    pub fn update_cached_usage(
+        &self,
+        environment: &EnvironmentKind,
+        account_id: Uuid,
+        usage: Option<crate::model::AccountUsageView>,
+    ) -> Result<SavedAccountMetadata> {
+        let mut index = self.index_store.load_index()?;
+        let position = index
+            .accounts
+            .iter()
+            .position(|account| account.id == account_id && &account.environment == environment)
+            .ok_or_else(|| anyhow!("saved account {account_id} not found"))?;
+        index.accounts[position].cached_usage = usage;
+        let metadata = index.accounts[position].clone();
         self.index_store.save_index(&index)?;
         Ok(metadata)
     }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -127,6 +127,33 @@ where
         Ok((metadata, snapshot))
     }
 
+    pub fn replace_snapshot(
+        &self,
+        environment: &EnvironmentKind,
+        account_id: Uuid,
+        identity: &DisplayIdentity,
+        snapshot: &SnapshotBlob,
+    ) -> Result<SavedAccountMetadata> {
+        let mut index = self.index_store.load_index()?;
+        let position = index
+            .accounts
+            .iter()
+            .position(|account| account.id == account_id && &account.environment == environment)
+            .ok_or_else(|| anyhow!("saved account {account_id} not found"))?;
+        let encoded_snapshot = encode_snapshot(snapshot)?;
+        let account = &mut index.accounts[position];
+        account.email = identity.email.clone();
+        account.subject = identity.subject.clone();
+        account.name = identity.name.clone();
+        account.plan_label = identity.plan_label.clone();
+        account.updated_at = OffsetDateTime::now_utc();
+        let metadata = account.clone();
+        self.secret_store
+            .save(&metadata.secret_key, &encoded_snapshot)?;
+        self.index_store.save_index(&index)?;
+        Ok(metadata)
+    }
+
     pub fn delete_snapshot(&self, environment: &EnvironmentKind, account_id: Uuid) -> Result<()> {
         let mut index = self.index_store.load_index()?;
         let Some(position) = index

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -24,6 +24,7 @@ pub struct UsageTarget {
     pub identity: DisplayIdentity,
     pub snapshot: SnapshotBlob,
     pub source: UsageSource,
+    pub allow_refresh: bool,
 }
 
 pub fn fetch_usage(target: UsageTarget) -> Result<(UsageOutput, SnapshotBlob)> {
@@ -32,7 +33,7 @@ pub fn fetch_usage(target: UsageTarget) -> Result<(UsageOutput, SnapshotBlob)> {
 
     let response = match fetch_usage_response(&auth.access_token, auth.account_id.as_deref()) {
         Ok(response) => response,
-        Err(error) if should_refresh_after_error(&error, &auth) => {
+        Err(error) if target.allow_refresh && should_refresh_after_error(&error, &auth) => {
             auth = refresh_auth(&auth)?;
             source = refresh_source(source);
             fetch_usage_response(&auth.access_token, auth.account_id.as_deref())?
@@ -352,6 +353,7 @@ pub fn usage_target_from_snapshot(
     environment: EnvironmentKind,
     snapshot: SnapshotBlob,
     source: UsageSource,
+    allow_refresh: bool,
 ) -> Result<UsageTarget> {
     let auth_file = snapshot
         .files
@@ -367,5 +369,6 @@ pub fn usage_target_from_snapshot(
         identity,
         snapshot,
         source,
+        allow_refresh,
     })
 }

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -1,0 +1,371 @@
+use std::sync::LazyLock;
+
+use anyhow::{Context, Result, anyhow, bail};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use serde::{Deserialize, Serialize};
+use time::format_description::well_known::Rfc3339;
+use time::{Duration, OffsetDateTime};
+
+use crate::identity::parse_identity_from_auth_json;
+use crate::model::{
+    AccountUsageView, CreditsView, DisplayIdentity, EnvironmentKind, SnapshotBlob, UsageOutput,
+    UsageSource, UsageWindowView,
+};
+
+static CHATGPT_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+static USAGE_ENDPOINT: &str = "https://chatgpt.com/backend-api/wham/usage";
+static REFRESH_ENDPOINT: &str = "https://auth.openai.com/oauth/token";
+static TOKEN_REFRESH_INTERVAL: LazyLock<Duration> = LazyLock::new(|| Duration::days(8));
+
+#[derive(Clone, Debug)]
+pub struct UsageTarget {
+    pub environment: EnvironmentKind,
+    pub identity: DisplayIdentity,
+    pub snapshot: SnapshotBlob,
+    pub source: UsageSource,
+}
+
+pub fn fetch_usage(target: UsageTarget) -> Result<(UsageOutput, SnapshotBlob)> {
+    let mut auth = snapshot_auth(&target.snapshot)?;
+    let mut source = target.source;
+
+    let response = match fetch_usage_response(&auth.access_token, auth.account_id.as_deref()) {
+        Ok(response) => response,
+        Err(error) if should_refresh_after_error(&error, &auth) => {
+            auth = refresh_auth(&auth)?;
+            source = refresh_source(source);
+            fetch_usage_response(&auth.access_token, auth.account_id.as_deref())?
+        }
+        Err(error) => return Err(error),
+    };
+
+    let snapshot = if auth.changed {
+        update_snapshot_auth(&target.snapshot, &auth)?
+    } else {
+        target.snapshot
+    };
+
+    let fetched_identity = merge_identity(&target.identity, response.identity()?);
+    Ok((
+        UsageOutput {
+            environment: target.environment,
+            account: fetched_identity,
+            usage: response.into_view(source)?,
+        },
+        snapshot,
+    ))
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct StoredAuth {
+    tokens: StoredTokens,
+    #[serde(default)]
+    last_refresh: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct StoredTokens {
+    access_token: String,
+    refresh_token: Option<String>,
+    id_token: Option<String>,
+    account_id: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct SnapshotAuth {
+    access_token: String,
+    refresh_token: Option<String>,
+    id_token: Option<String>,
+    account_id: Option<String>,
+    last_refresh: Option<OffsetDateTime>,
+    changed: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct UsageResponse {
+    email: Option<String>,
+    plan_type: Option<String>,
+    rate_limit: Option<UsageRateLimit>,
+    credits: Option<UsageCredits>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UsageRateLimit {
+    primary_window: Option<UsageWindow>,
+    secondary_window: Option<UsageWindow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UsageWindow {
+    used_percent: u8,
+    reset_at: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct UsageCredits {
+    has_credits: bool,
+    unlimited: bool,
+    balance: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct RefreshResponse {
+    access_token: String,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    id_token: Option<String>,
+}
+
+impl UsageResponse {
+    fn identity(&self) -> Result<Option<DisplayIdentity>> {
+        let Some(email) = &self.email else {
+            return Ok(None);
+        };
+        Ok(Some(DisplayIdentity {
+            email: email.clone(),
+            subject: None,
+            name: None,
+            plan_label: normalize_plan_label(self.plan_type.as_deref()),
+        }))
+    }
+
+    fn into_view(self, source: UsageSource) -> Result<AccountUsageView> {
+        let now = OffsetDateTime::now_utc();
+        Ok(AccountUsageView {
+            source,
+            fetched_at: now,
+            five_hour: self
+                .rate_limit
+                .as_ref()
+                .and_then(|limits| limits.primary_window.as_ref())
+                .map(window_view)
+                .transpose()?,
+            weekly: self
+                .rate_limit
+                .as_ref()
+                .and_then(|limits| limits.secondary_window.as_ref())
+                .map(window_view)
+                .transpose()?,
+            credits: self.credits.map(credits_view),
+        })
+    }
+}
+
+fn snapshot_auth(snapshot: &SnapshotBlob) -> Result<SnapshotAuth> {
+    let auth_file = snapshot
+        .files
+        .iter()
+        .find(|file| file.name == "auth.json")
+        .context("snapshot missing auth.json")?;
+    let auth_json = STANDARD
+        .decode(&auth_file.bytes_base64)
+        .context("failed to decode snapshot auth.json")?;
+    let stored: StoredAuth =
+        serde_json::from_slice(&auth_json).context("failed to parse snapshot auth.json")?;
+    Ok(SnapshotAuth {
+        access_token: stored.tokens.access_token,
+        refresh_token: stored.tokens.refresh_token,
+        id_token: stored.tokens.id_token,
+        account_id: stored.tokens.account_id,
+        last_refresh: parse_last_refresh(stored.last_refresh.as_deref())?,
+        changed: false,
+    })
+}
+
+fn update_snapshot_auth(snapshot: &SnapshotBlob, auth: &SnapshotAuth) -> Result<SnapshotBlob> {
+    let mut updated = snapshot.clone();
+    let auth_index = updated
+        .files
+        .iter()
+        .position(|file| file.name == "auth.json")
+        .context("snapshot missing auth.json")?;
+    let auth_json = STANDARD
+        .decode(&updated.files[auth_index].bytes_base64)
+        .context("failed to decode snapshot auth.json")?;
+    let mut stored: StoredAuth =
+        serde_json::from_slice(&auth_json).context("failed to parse snapshot auth.json")?;
+    stored.tokens.access_token = auth.access_token.clone();
+    stored.tokens.refresh_token = auth.refresh_token.clone();
+    stored.tokens.id_token = auth.id_token.clone();
+    stored.tokens.account_id = auth.account_id.clone();
+    stored.last_refresh = auth.last_refresh.map(format_last_refresh);
+    updated.files[auth_index].bytes_base64 = STANDARD.encode(
+        serde_json::to_vec_pretty(&stored).context("failed to encode refreshed auth.json")?,
+    );
+    Ok(updated)
+}
+
+fn fetch_usage_response(access_token: &str, account_id: Option<&str>) -> Result<UsageResponse> {
+    let mut request = ureq::get(USAGE_ENDPOINT)
+        .header("Authorization", &format!("Bearer {access_token}"))
+        .header("User-Agent", "codex-account-switcher")
+        .config()
+        .http_status_as_error(false)
+        .timeout_global(Some(std::time::Duration::from_secs(5)))
+        .build();
+    if let Some(account_id) = account_id {
+        request = request.header("ChatGPT-Account-Id", account_id);
+    }
+    let mut response = request.call().context("failed to query Codex usage")?;
+    let status = response.status();
+    if status == 401 || status == 403 {
+        bail!("usage authorization failed");
+    }
+    if status.as_u16() >= 400 {
+        let body = response.body_mut().read_to_string().unwrap_or_default();
+        bail!("usage request failed with {status}: {body}");
+    }
+    response
+        .body_mut()
+        .read_json::<UsageResponse>()
+        .context("failed to decode Codex usage response")
+}
+
+fn should_refresh_after_error(error: &anyhow::Error, auth: &SnapshotAuth) -> bool {
+    if auth.refresh_token.as_deref().is_none_or(str::is_empty) {
+        return false;
+    }
+    if auth.last_refresh.is_some_and(|last_refresh| {
+        OffsetDateTime::now_utc() - last_refresh < *TOKEN_REFRESH_INTERVAL
+    }) {
+        return format!("{error:#}").contains("authorization failed");
+    }
+    true
+}
+
+fn refresh_auth(auth: &SnapshotAuth) -> Result<SnapshotAuth> {
+    let refresh_token = auth
+        .refresh_token
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .context("snapshot refresh token missing")?;
+    let payload = serde_json::json!({
+        "client_id": CHATGPT_CLIENT_ID,
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "scope": "openid profile email"
+    });
+    let payload_json =
+        serde_json::to_string(&payload).context("failed to encode refresh payload")?;
+    let mut response = ureq::post(REFRESH_ENDPOINT)
+        .header("Content-Type", "application/json")
+        .config()
+        .http_status_as_error(false)
+        .timeout_global(Some(std::time::Duration::from_secs(5)))
+        .build()
+        .send(&payload_json)
+        .context("failed to refresh Codex auth tokens")?;
+    let status = response.status();
+    if status.as_u16() >= 400 {
+        let body = response.body_mut().read_to_string().unwrap_or_default();
+        bail!("token refresh failed with {status}: {body}");
+    }
+    let refreshed = response
+        .body_mut()
+        .read_json::<RefreshResponse>()
+        .context("failed to decode refreshed Codex tokens")?;
+    Ok(SnapshotAuth {
+        access_token: refreshed.access_token,
+        refresh_token: refreshed
+            .refresh_token
+            .or_else(|| auth.refresh_token.clone()),
+        id_token: refreshed.id_token.or_else(|| auth.id_token.clone()),
+        account_id: auth.account_id.clone(),
+        last_refresh: Some(OffsetDateTime::now_utc()),
+        changed: true,
+    })
+}
+
+fn refresh_source(source: UsageSource) -> UsageSource {
+    match source {
+        UsageSource::LiveAccessToken | UsageSource::LiveRefreshToken => {
+            UsageSource::LiveRefreshToken
+        }
+        UsageSource::SavedAccessToken | UsageSource::SavedRefreshToken => {
+            UsageSource::SavedRefreshToken
+        }
+    }
+}
+
+fn window_view(window: &UsageWindow) -> Result<UsageWindowView> {
+    let reset_at = OffsetDateTime::from_unix_timestamp(window.reset_at)
+        .map_err(|error| anyhow!("invalid reset timestamp {}: {error}", window.reset_at))?;
+    Ok(UsageWindowView {
+        used_percent: window.used_percent,
+        remaining_percent: 100u8.saturating_sub(window.used_percent),
+        reset_at,
+    })
+}
+
+fn credits_view(credits: UsageCredits) -> CreditsView {
+    CreditsView {
+        has_credits: credits.has_credits,
+        unlimited: credits.unlimited,
+        balance: match credits.balance {
+            serde_json::Value::String(value) => value,
+            other => other.to_string(),
+        },
+    }
+}
+
+fn normalize_plan_label(raw: Option<&str>) -> Option<String> {
+    match raw?.trim() {
+        "" => None,
+        "go" => Some("Go".to_owned()),
+        "plus" => Some("Plus".to_owned()),
+        "pro" => Some("Pro".to_owned()),
+        "free" => Some("Free".to_owned()),
+        other => Some(other.to_owned()),
+    }
+}
+
+fn merge_identity(base: &DisplayIdentity, fetched: Option<DisplayIdentity>) -> DisplayIdentity {
+    let Some(fetched) = fetched else {
+        return base.clone();
+    };
+    DisplayIdentity {
+        email: fetched.email,
+        subject: base.subject.clone(),
+        name: base.name.clone(),
+        plan_label: fetched.plan_label.or_else(|| base.plan_label.clone()),
+    }
+}
+
+fn parse_last_refresh(value: Option<&str>) -> Result<Option<OffsetDateTime>> {
+    value
+        .map(|value| {
+            OffsetDateTime::parse(value, &Rfc3339)
+                .map_err(|error| anyhow!("failed to parse last_refresh {value:?}: {error}"))
+        })
+        .transpose()
+}
+
+fn format_last_refresh(value: OffsetDateTime) -> String {
+    value
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| value.unix_timestamp().to_string())
+}
+
+pub fn usage_target_from_snapshot(
+    environment: EnvironmentKind,
+    snapshot: SnapshotBlob,
+    source: UsageSource,
+) -> Result<UsageTarget> {
+    let auth_file = snapshot
+        .files
+        .iter()
+        .find(|file| file.name == "auth.json")
+        .context("snapshot missing auth.json")?;
+    let auth_json = STANDARD
+        .decode(&auth_file.bytes_base64)
+        .context("failed to decode snapshot auth.json")?;
+    let identity = parse_identity_from_auth_json(&auth_json)?;
+    Ok(UsageTarget {
+        environment,
+        identity,
+        snapshot,
+        source,
+    })
+}


### PR DESCRIPTION
## Summary
- add a backend `usage` command that reads live or saved Codex auth snapshots, queries usage/reset data, and emits machine-readable output
- cache saved-account usage for `list` and the interactive TUI while keeping list rendering local-only
- persist refreshed saved snapshots and carefully persist refreshed live auth when the live bundle still matches the original snapshot

## Validation
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- review-phase rounds on the committed branch until locally green-enough

## Notes
- usage data comes from the saved/live `auth.json` snapshot path rather than `/status` or UI scraping
- live refresh writeback is guarded to avoid clobbering a concurrently changed live bundle