### PR TITLE
feat(usage): add auto-start usage windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ codex-account-switcher save [--json]
 codex-account-switcher usage [ACCOUNT_ID] [--json]
 codex-account-switcher activate [ACCOUNT_ID] [--force] [--json]
 codex-account-switcher delete [ACCOUNT_ID] [--json]
+codex-account-switcher auto-start-usage-windows [--enable|--disable] [--run] [--json]
 ```
 
 ## Behavior
@@ -40,6 +41,7 @@ codex-account-switcher delete [ACCOUNT_ID] [--json]
 - `usage` fetches current usage for the live account or for a saved account by id.
 - `activate` restores a saved snapshot. Reliable swaps require all Codex processes to be closed first; `--force` lets the command attempt activation anyway, but it still fails if the restored files do not stay stable.
 - `delete` removes the saved snapshot from the switcher store only.
+- `auto-start-usage-windows` is opt-in from the CLI, TUI, or tray checkmark. When enabled, the interactive app refreshes saved weekly windows every 5 minutes and starts due windows with a minimal `codex exec` ping when Codex is on `PATH`.
 
 Saved snapshot data lives in the app-data directory for the current environment:
 
@@ -113,3 +115,4 @@ cargo fmt --check
 - Saved snapshots are keyed by the current environment and current account identity.
 - Plan metadata is best effort and may be blank if the token does not expose a recognizable value.
 - Usage enrichment depends on saved `auth.json` tokens still being present and accepted by the Codex/OpenAI usage endpoints.
+- Auto-starting usage windows can ping while Codex processes are running; active Codex sessions keep their auth cached, and the switcher restores the previous live account afterward.

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,6 +2,8 @@ mod auto_start;
 mod service;
 mod tui;
 
+use std::sync::{Mutex, MutexGuard};
+
 use uuid::Uuid;
 
 pub use auto_start::spawn_auto_start_usage_windows_worker;
@@ -15,6 +17,14 @@ use crate::repository::SnapshotRepository;
 pub struct App<S> {
     env: AppEnv,
     repository: SnapshotRepository<S>,
+}
+
+static AUTH_MUTATION_LOCK: Mutex<()> = Mutex::new(());
+
+pub(super) fn auth_mutation_lock() -> MutexGuard<'static, ()> {
+    AUTH_MUTATION_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 #[derive(Clone, Copy)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@ mod tui;
 
 use uuid::Uuid;
 
+pub(crate) use auto_start::run_auto_start_usage_windows_check_now;
 pub use auto_start::spawn_auto_start_usage_windows_worker;
 
 use crate::env::AppEnv;

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,8 +2,6 @@ mod auto_start;
 mod service;
 mod tui;
 
-use std::sync::{Mutex, MutexGuard};
-
 use uuid::Uuid;
 
 pub use auto_start::spawn_auto_start_usage_windows_worker;
@@ -17,14 +15,6 @@ use crate::repository::SnapshotRepository;
 pub struct App<S> {
     env: AppEnv,
     repository: SnapshotRepository<S>,
-}
-
-static AUTH_MUTATION_LOCK: Mutex<()> = Mutex::new(());
-
-pub(super) fn auth_mutation_lock() -> MutexGuard<'static, ()> {
-    AUTH_MUTATION_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 #[derive(Clone, Copy)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@ mod tui;
 
 use uuid::Uuid;
 
+#[cfg(windows)]
 pub(crate) use auto_start::run_auto_start_usage_windows_check_now;
 pub use auto_start::spawn_auto_start_usage_windows_worker;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,10 @@
+mod auto_start;
 mod service;
 mod tui;
 
 use uuid::Uuid;
+
+pub use auto_start::spawn_auto_start_usage_windows_worker;
 
 use crate::env::AppEnv;
 use crate::model::{

--- a/src/app/auto_start.rs
+++ b/src/app/auto_start.rs
@@ -19,7 +19,7 @@ use crate::repository::SnapshotRepository;
 use crate::secrets::{MigratingSecretStore, SecretStore};
 use crate::settings::{load_settings, save_settings};
 
-use super::{App, saved_identity};
+use super::{App, auth_mutation_lock, saved_identity};
 
 pub const AUTO_START_USAGE_WINDOW_POLL_SECONDS: u64 = 300;
 
@@ -62,6 +62,7 @@ where
             return Ok(output);
         }
 
+        let _guard = auth_mutation_lock();
         let accounts = self.repository.list_accounts(&self.env.kind)?;
         output.checked_accounts = accounts.len();
         let now = OffsetDateTime::now_utc();
@@ -116,7 +117,7 @@ where
         }
 
         if let Some(account_id) = original_saved_account_id {
-            if let Err(error) = self.activate_with_running_policy(account_id, false) {
+            if let Err(error) = self.restore_account_for_auto_start(account_id) {
                 codex::restore_snapshot(&self.env, &original.snapshot, &original.identity, false)
                     .with_context(|| {
                     format!("failed to restore original account after activation failed: {error:#}")
@@ -136,9 +137,9 @@ where
         email: &str,
         selected_model: Option<&str>,
     ) -> Result<AutoStartUsageWindowAccountResult> {
-        self.activate_with_running_policy(account_id, false)?;
+        self.restore_account_for_auto_start(account_id)?;
         run_codex_usage_ping(selected_model)?;
-        let saved = self.save_current()?;
+        let saved = self.save_current_unlocked()?;
         let usage = self.usage(Some(saved.account.id))?;
         let now = OffsetDateTime::now_utc();
         let status = match usage.usage.weekly {
@@ -152,6 +153,17 @@ where
             status: status.to_owned(),
             detail: None,
         })
+    }
+
+    fn restore_account_for_auto_start(&self, account_id: Uuid) -> Result<()> {
+        let (snapshot, snapshot_identity, restore_identity) =
+            self.load_activation_target(account_id)?;
+        codex::restore_snapshot(&self.env, &snapshot, &restore_identity, false)
+            .context("failed to restore usage-window account snapshot")?;
+        self.repository
+            .sync_activated_account(&self.env.kind, account_id, &snapshot_identity)
+            .context("restored usage-window account but failed to update local metadata")?;
+        Ok(())
     }
 }
 

--- a/src/app/auto_start.rs
+++ b/src/app/auto_start.rs
@@ -6,7 +6,6 @@ use std::thread;
 use std::time::{Duration as StdDuration, Instant};
 
 use anyhow::{Context, Result, anyhow};
-use serde_json::Value;
 use time::OffsetDateTime;
 use uuid::Uuid;
 
@@ -94,7 +93,6 @@ where
                     account_id,
                     email,
                     status: "failed".to_owned(),
-                    selected_model: None,
                     detail: Some(format!("{error:#}")),
                 },
             };
@@ -111,20 +109,19 @@ where
     ) -> Result<AutoStartUsageWindowAccountResult> {
         let (_, snapshot) = self.repository.load_snapshot(&self.env.kind, account_id)?;
         let identity = codex::identity_from_snapshot(&snapshot)?;
-        let (refreshed_snapshot, selected_model) =
-            run_codex_usage_ping(&self.env, &snapshot, &identity)?;
+        let ping_result = run_codex_usage_ping(&self.env, &snapshot, &identity)?;
         let (_, current_snapshot) = self.repository.load_snapshot(&self.env.kind, account_id)?;
         if current_snapshot != snapshot {
             return Err(anyhow!(
                 "saved snapshot changed while ping was running; skipped write-back"
             ));
         }
-        let refreshed_identity = codex::identity_from_snapshot(&refreshed_snapshot)?;
+        let refreshed_identity = codex::identity_from_snapshot(&ping_result.snapshot)?;
         self.repository.replace_snapshot(
             &self.env.kind,
             account_id,
             &refreshed_identity,
-            &refreshed_snapshot,
+            &ping_result.snapshot,
             None,
         )?;
         let usage = self.usage(Some(account_id))?;
@@ -138,8 +135,7 @@ where
             account_id,
             email: email.to_owned(),
             status: status.to_owned(),
-            selected_model,
-            detail: None,
+            detail: ping_result.cleanup_warning,
         })
     }
 }
@@ -186,18 +182,29 @@ fn usage_window_needs_ping(reset_at: OffsetDateTime, now: OffsetDateTime) -> boo
     reset_at <= now
 }
 
+struct CodexUsagePingResult {
+    snapshot: SnapshotBlob,
+    cleanup_warning: Option<String>,
+}
+
 fn run_codex_usage_ping(
     env: &AppEnv,
     snapshot: &SnapshotBlob,
     identity: &DisplayIdentity,
-) -> Result<(SnapshotBlob, Option<String>)> {
+) -> Result<CodexUsagePingResult> {
     let work_dir =
         std::env::temp_dir().join(format!("codex-account-switcher-ping-{}", Uuid::new_v4()));
     let result = run_codex_usage_ping_in_temp_home(env, snapshot, identity, &work_dir);
     let cleanup = remove_temp_auth_home(&work_dir);
     match (result, cleanup) {
-        (Ok(value), Ok(())) => Ok(value),
-        (Ok(_), Err(error)) => Err(error),
+        (Ok(snapshot), Ok(())) => Ok(CodexUsagePingResult {
+            snapshot,
+            cleanup_warning: None,
+        }),
+        (Ok(snapshot), Err(error)) => Ok(CodexUsagePingResult {
+            snapshot,
+            cleanup_warning: Some(format!("temporary auth cleanup failed: {error:#}")),
+        }),
         (Err(error), Ok(())) => Err(error),
         (Err(error), Err(cleanup_error)) => Err(error.context(format!(
             "also failed to remove temporary auth home: {cleanup_error:#}"
@@ -210,7 +217,7 @@ fn run_codex_usage_ping_in_temp_home(
     snapshot: &SnapshotBlob,
     identity: &DisplayIdentity,
     work_dir: &Path,
-) -> Result<(SnapshotBlob, Option<String>)> {
+) -> Result<SnapshotBlob> {
     fs::create_dir_all(work_dir)
         .with_context(|| format!("failed to create {}", work_dir.display()))?;
     let temp_env = AppEnv {
@@ -226,7 +233,6 @@ fn run_codex_usage_ping_in_temp_home(
     fs::write(&instruction_file, PING_INSTRUCTIONS)
         .with_context(|| format!("failed to write {}", instruction_file.display()))?;
 
-    let selected_model = best_available_mini_model(&temp_env.codex_root);
     let mut command = Command::new("codex");
     command
         .env("CODEX_HOME", &temp_env.codex_root)
@@ -253,9 +259,6 @@ fn run_codex_usage_ping_in_temp_home(
         ))
         .arg("-c")
         .arg("model_reasoning_effort=\"low\"");
-    if let Some(model) = selected_model.as_deref() {
-        command.arg("-m").arg(model);
-    }
     command
         .arg(PING_PROMPT)
         .stdin(Stdio::null())
@@ -270,7 +273,7 @@ fn run_codex_usage_ping_in_temp_home(
     }
     let refreshed = codex::read_live_auth_bundle(&temp_env)
         .context("failed to read refreshed temporary Codex auth")?;
-    Ok((refreshed.snapshot, selected_model))
+    Ok(refreshed.snapshot)
 }
 
 fn remove_temp_auth_home(path: &Path) -> Result<()> {
@@ -311,60 +314,6 @@ fn strip_codex_thread_env(command: &mut Command) {
     }
 }
 
-fn best_available_mini_model(codex_home: &Path) -> Option<String> {
-    for bundled in [false, true] {
-        let mut command = Command::new("codex");
-        command.env("CODEX_HOME", codex_home);
-        command.arg("debug").arg("models");
-        if bundled {
-            command.arg("--bundled");
-        }
-        strip_codex_thread_env(&mut command);
-        let Ok(output) = command.output() else {
-            continue;
-        };
-        if !output.status.success() {
-            continue;
-        }
-        let raw = String::from_utf8_lossy(&output.stdout);
-        if let Some(model) = select_mini_model_from_catalog(&raw) {
-            return Some(model);
-        }
-    }
-    None
-}
-
-fn select_mini_model_from_catalog(raw: &str) -> Option<String> {
-    let value: Value = serde_json::from_str(raw).ok()?;
-    let models = if let Some(models) = value.get("models").and_then(Value::as_array) {
-        models
-    } else {
-        value.as_array()?
-    };
-    let mut candidates = models
-        .iter()
-        .enumerate()
-        .filter_map(|(position, model)| {
-            let slug = model
-                .get("slug")
-                .or_else(|| model.get("id"))
-                .and_then(Value::as_str)?;
-            if !slug.ends_with("-mini")
-                || model.get("supported_in_api").and_then(Value::as_bool) == Some(false)
-            {
-                return None;
-            }
-            let priority = model
-                .get("priority")
-                .and_then(Value::as_i64)
-                .unwrap_or(i64::MAX);
-            Some((priority, position, slug.to_owned()))
-        })
-        .collect::<Vec<_>>();
-    candidates.sort_by_key(|(priority, position, _)| (*priority, *position));
-    candidates.into_iter().map(|(_, _, slug)| slug).next()
-}
-
 fn toml_string_literal(value: &str) -> String {
     let mut literal = String::from("\"");
     for character in value.chars() {
@@ -394,35 +343,6 @@ mod tests {
         assert!(usage_window_needs_ping(now, now));
         assert!(usage_window_needs_ping(now - Duration::minutes(1), now));
         assert!(!usage_window_needs_ping(now + Duration::minutes(1), now));
-    }
-
-    #[test]
-    fn mini_model_selector_prefers_lowest_priority_available_mini() {
-        let raw = r#"{
-          "models": [
-            {"slug": "gpt-5.5", "priority": 1, "supported_in_api": true},
-            {"slug": "gpt-5.3-mini", "priority": 20, "supported_in_api": true},
-            {"slug": "gpt-5.4-mini", "priority": 10, "supported_in_api": true}
-          ]
-        }"#;
-
-        assert_eq!(
-            select_mini_model_from_catalog(raw).as_deref(),
-            Some("gpt-5.4-mini")
-        );
-    }
-
-    #[test]
-    fn mini_model_selector_skips_api_unsupported_models() {
-        let raw = r#"[
-          {"slug": "gpt-hidden-mini", "priority": 1, "supported_in_api": false},
-          {"slug": "gpt-visible-mini", "priority": 2, "supported_in_api": true}
-        ]"#;
-
-        assert_eq!(
-            select_mini_model_from_catalog(raw).as_deref(),
-            Some("gpt-visible-mini")
-        );
     }
 
     #[test]

--- a/src/app/auto_start.rs
+++ b/src/app/auto_start.rs
@@ -1,8 +1,9 @@
 use std::fs;
-use std::process::{Command, Stdio};
+use std::path::Path;
+use std::process::{Command, ExitStatus, Stdio};
 use std::sync::OnceLock;
 use std::thread;
-use std::time::Duration as StdDuration;
+use std::time::{Duration as StdDuration, Instant};
 
 use anyhow::{Context, Result, anyhow};
 use serde_json::Value;
@@ -10,16 +11,16 @@ use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::codex;
-use crate::env;
+use crate::env::{self, AppEnv};
 use crate::model::{
     AutoStartUsageWindowAccountResult, AutoStartUsageWindowsRunOutput,
-    AutoStartUsageWindowsStatusOutput,
+    AutoStartUsageWindowsStatusOutput, DisplayIdentity, SnapshotBlob,
 };
 use crate::repository::SnapshotRepository;
 use crate::secrets::{MigratingSecretStore, SecretStore};
 use crate::settings::{load_settings, save_settings};
 
-use super::{App, auth_mutation_lock, saved_identity};
+use super::App;
 
 pub const AUTO_START_USAGE_WINDOW_POLL_SECONDS: u64 = 300;
 
@@ -54,7 +55,6 @@ where
         let mut output = AutoStartUsageWindowsRunOutput {
             enabled,
             checked_accounts: 0,
-            selected_model: None,
             pinged_accounts: Vec::new(),
             skipped: Vec::new(),
         };
@@ -62,7 +62,6 @@ where
             return Ok(output);
         }
 
-        let _guard = auth_mutation_lock();
         let accounts = self.repository.list_accounts(&self.env.kind)?;
         output.checked_accounts = accounts.len();
         let now = OffsetDateTime::now_utc();
@@ -88,44 +87,18 @@ where
             return Ok(output);
         }
 
-        let Some(original) = codex::try_read_live_auth_bundle(&self.env)? else {
-            output
-                .skipped
-                .push("no live account to restore after ping".to_owned());
-            return Ok(output);
-        };
-        let original_saved_account_id = accounts
-            .iter()
-            .find(|account| saved_identity(account).matches(&original.identity))
-            .map(|account| account.id);
-
-        let selected_model = best_available_mini_model();
-        output.selected_model = selected_model.clone();
         for (account_id, email) in due_accounts {
-            let result =
-                match self.ping_usage_window_account(account_id, &email, selected_model.as_deref())
-                {
-                    Ok(result) => result,
-                    Err(error) => AutoStartUsageWindowAccountResult {
-                        account_id,
-                        email,
-                        status: "failed".to_owned(),
-                        detail: Some(format!("{error:#}")),
-                    },
-                };
+            let result = match self.ping_usage_window_account(account_id, &email) {
+                Ok(result) => result,
+                Err(error) => AutoStartUsageWindowAccountResult {
+                    account_id,
+                    email,
+                    status: "failed".to_owned(),
+                    selected_model: None,
+                    detail: Some(format!("{error:#}")),
+                },
+            };
             output.pinged_accounts.push(result);
-        }
-
-        if let Some(account_id) = original_saved_account_id {
-            if let Err(error) = self.restore_account_for_auto_start(account_id) {
-                codex::restore_snapshot(&self.env, &original.snapshot, &original.identity, false)
-                    .with_context(|| {
-                    format!("failed to restore original account after activation failed: {error:#}")
-                })?;
-            }
-        } else {
-            codex::restore_snapshot(&self.env, &original.snapshot, &original.identity, false)
-                .context("failed to restore original account after usage-window ping")?;
         }
 
         Ok(output)
@@ -135,12 +108,20 @@ where
         &self,
         account_id: Uuid,
         email: &str,
-        selected_model: Option<&str>,
     ) -> Result<AutoStartUsageWindowAccountResult> {
-        self.restore_account_for_auto_start(account_id)?;
-        run_codex_usage_ping(selected_model)?;
-        let saved = self.save_current_unlocked()?;
-        let usage = self.usage(Some(saved.account.id))?;
+        let (_, snapshot) = self.repository.load_snapshot(&self.env.kind, account_id)?;
+        let identity = codex::identity_from_snapshot(&snapshot)?;
+        let (refreshed_snapshot, selected_model) =
+            run_codex_usage_ping(&self.env, &snapshot, &identity)?;
+        let refreshed_identity = codex::identity_from_snapshot(&refreshed_snapshot)?;
+        self.repository.replace_snapshot(
+            &self.env.kind,
+            account_id,
+            &refreshed_identity,
+            &refreshed_snapshot,
+            None,
+        )?;
+        let usage = self.usage(Some(account_id))?;
         let now = OffsetDateTime::now_utc();
         let status = match usage.usage.weekly {
             Some(weekly) if weekly.reset_at > now => "started",
@@ -151,19 +132,9 @@ where
             account_id,
             email: email.to_owned(),
             status: status.to_owned(),
+            selected_model,
             detail: None,
         })
-    }
-
-    fn restore_account_for_auto_start(&self, account_id: Uuid) -> Result<()> {
-        let (snapshot, snapshot_identity, restore_identity) =
-            self.load_activation_target(account_id)?;
-        codex::restore_snapshot(&self.env, &snapshot, &restore_identity, false)
-            .context("failed to restore usage-window account snapshot")?;
-        self.repository
-            .sync_activated_account(&self.env.kind, account_id, &snapshot_identity)
-            .context("restored usage-window account but failed to update local metadata")?;
-        Ok(())
     }
 }
 
@@ -205,24 +176,52 @@ fn usage_window_needs_ping(reset_at: OffsetDateTime, now: OffsetDateTime) -> boo
     reset_at <= now
 }
 
-fn run_codex_usage_ping(selected_model: Option<&str>) -> Result<()> {
+fn run_codex_usage_ping(
+    env: &AppEnv,
+    snapshot: &SnapshotBlob,
+    identity: &DisplayIdentity,
+) -> Result<(SnapshotBlob, Option<String>)> {
     let work_dir =
         std::env::temp_dir().join(format!("codex-account-switcher-ping-{}", Uuid::new_v4()));
-    fs::create_dir_all(&work_dir)
+    let result = run_codex_usage_ping_in_temp_home(env, snapshot, identity, &work_dir);
+    let _ = fs::remove_dir_all(&work_dir);
+    result
+}
+
+fn run_codex_usage_ping_in_temp_home(
+    env: &AppEnv,
+    snapshot: &SnapshotBlob,
+    identity: &DisplayIdentity,
+    work_dir: &Path,
+) -> Result<(SnapshotBlob, Option<String>)> {
+    fs::create_dir_all(work_dir)
         .with_context(|| format!("failed to create {}", work_dir.display()))?;
+    let temp_env = AppEnv {
+        kind: env.kind.clone(),
+        home_dir: work_dir.to_path_buf(),
+        codex_root: work_dir.join("codex-home"),
+        app_data_dir: work_dir.join("app-data"),
+    };
+    codex::restore_snapshot(&temp_env, snapshot, identity, false)
+        .context("failed to seed temporary Codex auth home")?;
+
     let instruction_file = work_dir.join("instructions.md");
     fs::write(&instruction_file, PING_INSTRUCTIONS)
         .with_context(|| format!("failed to write {}", instruction_file.display()))?;
 
+    let selected_model = best_available_mini_model(&temp_env.codex_root);
     let mut command = Command::new("codex");
     command
+        .env("CODEX_HOME", &temp_env.codex_root)
         .arg("exec")
         .arg("--ephemeral")
         .arg("--ignore-user-config")
         .arg("--ignore-rules")
         .arg("--skip-git-repo-check")
         .arg("--cd")
-        .arg(&work_dir)
+        .arg(work_dir)
+        .arg("-c")
+        .arg("cli_auth_credentials_store=\"file\"")
         .arg("-c")
         .arg(format!(
             "model_instructions_file={}",
@@ -230,29 +229,40 @@ fn run_codex_usage_ping(selected_model: Option<&str>) -> Result<()> {
         ))
         .arg("-c")
         .arg("model_reasoning_effort=\"low\"");
-    if let Some(model) = selected_model {
+    if let Some(model) = selected_model.as_deref() {
         command.arg("-m").arg(model);
     }
     command
         .arg(PING_PROMPT)
         .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
     strip_codex_thread_env(&mut command);
 
-    let output = command.output();
-    let _ = fs::remove_dir_all(&work_dir);
-    let output = output.context("failed to run `codex exec`; make sure `codex` is on PATH")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
-        let detail = if stderr.is_empty() { stdout } else { stderr };
-        return Err(anyhow!(
-            "`codex exec` failed with {}: {detail}",
-            output.status
-        ));
+    let status = run_command_with_timeout(&mut command, StdDuration::from_secs(120))
+        .context("failed to run `codex exec`; make sure `codex` is on PATH")?;
+    if !status.success() {
+        return Err(anyhow!("`codex exec` failed with {status}"));
     }
-    Ok(())
+    let refreshed = codex::read_live_auth_bundle(&temp_env)
+        .context("failed to read refreshed temporary Codex auth")?;
+    Ok((refreshed.snapshot, selected_model))
+}
+
+fn run_command_with_timeout(command: &mut Command, timeout: StdDuration) -> Result<ExitStatus> {
+    let mut child = command.spawn()?;
+    let started = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status);
+        }
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(anyhow!("process timed out after {}s", timeout.as_secs()));
+        }
+        thread::sleep(StdDuration::from_millis(100));
+    }
 }
 
 fn strip_codex_thread_env(command: &mut Command) {
@@ -261,15 +271,18 @@ fn strip_codex_thread_env(command: &mut Command) {
     }
 }
 
-fn best_available_mini_model() -> Option<String> {
+fn best_available_mini_model(codex_home: &Path) -> Option<String> {
     for bundled in [false, true] {
         let mut command = Command::new("codex");
+        command.env("CODEX_HOME", codex_home);
         command.arg("debug").arg("models");
         if bundled {
             command.arg("--bundled");
         }
         strip_codex_thread_env(&mut command);
-        let output = command.output().ok()?;
+        let Ok(output) = command.output() else {
+            continue;
+        };
         if !output.status.success() {
             continue;
         }

--- a/src/app/auto_start.rs
+++ b/src/app/auto_start.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 use crate::codex;
 use crate::env::{self, AppEnv};
 use crate::model::{
-    AutoStartUsageWindowAccountResult, AutoStartUsageWindowsRunOutput,
+    AUTH_FILES, AutoStartUsageWindowAccountResult, AutoStartUsageWindowsRunOutput,
     AutoStartUsageWindowsStatusOutput, DisplayIdentity, SnapshotBlob,
 };
 use crate::repository::SnapshotRepository;
@@ -202,10 +202,22 @@ fn run_codex_usage_ping(
             snapshot,
             cleanup_warning: None,
         }),
-        (Ok(snapshot), Err(error)) => Ok(CodexUsagePingResult {
-            snapshot,
-            cleanup_warning: Some(format!("temporary auth cleanup failed: {error:#}")),
-        }),
+        (Ok(snapshot), Err(error)) => {
+            scrub_temp_auth_material(&work_dir)
+                .context("temporary auth cleanup failed and auth scrub failed")?;
+            let cleanup_warning = match remove_temp_auth_home(&work_dir) {
+                Ok(()) => {
+                    format!("temporary auth cleanup initially failed, then recovered: {error:#}")
+                }
+                Err(final_error) => format!(
+                    "temporary auth cleanup failed after auth scrub; non-auth temp files may remain: {error:#}; final cleanup failed: {final_error:#}"
+                ),
+            };
+            Ok(CodexUsagePingResult {
+                snapshot,
+                cleanup_warning: Some(cleanup_warning),
+            })
+        }
         (Err(error), Ok(())) => Err(error),
         (Err(error), Err(cleanup_error)) => Err(error.context(format!(
             "also failed to remove temporary auth home: {cleanup_error:#}"
@@ -293,6 +305,59 @@ fn remove_temp_auth_home(path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn scrub_temp_auth_material(work_dir: &Path) -> Result<()> {
+    let codex_home = work_dir.join("codex-home");
+    match fs::remove_dir_all(&codex_home) {
+        Ok(()) => return Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(_) => {}
+    }
+
+    let mut errors = Vec::new();
+    for file_name in AUTH_FILES {
+        remove_file_if_exists(&codex_home.join(file_name), &mut errors);
+    }
+    match fs::read_dir(&codex_home) {
+        Ok(entries) => {
+            for entry in entries.flatten() {
+                let file_name = entry.file_name();
+                if file_name.to_string_lossy().starts_with(".cas-") {
+                    remove_dir_if_exists(&entry.path(), &mut errors);
+                }
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => errors.push(format!(
+            "failed to inspect {}: {error}",
+            codex_home.display()
+        )),
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "failed to scrub temporary auth material: {}",
+            errors.join("; ")
+        ))
+    }
+}
+
+fn remove_file_if_exists(path: &Path, errors: &mut Vec<String>) {
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => errors.push(format!("failed to remove {}: {error}", path.display())),
+    }
+}
+
+fn remove_dir_if_exists(path: &Path, errors: &mut Vec<String>) {
+    match fs::remove_dir_all(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => errors.push(format!("failed to remove {}: {error}", path.display())),
+    }
+}
+
 fn run_command_with_timeout(command: &mut Command, timeout: StdDuration) -> Result<ExitStatus> {
     let mut child = command.spawn()?;
     let started = Instant::now();
@@ -352,5 +417,22 @@ mod tests {
             toml_string_literal(r#"C:\Temp\codex "ping"\instructions.md"#),
             r#""C:\\Temp\\codex \"ping\"\\instructions.md""#
         );
+    }
+
+    #[test]
+    fn scrub_temp_auth_material_removes_managed_auth_files() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let codex_home = temp.path().join("codex-home");
+        let backup_dir = codex_home.join(".cas-backup-test");
+        fs::create_dir_all(&backup_dir)?;
+        fs::write(codex_home.join("auth.json"), "{}")?;
+        fs::write(codex_home.join("cap_sid"), "sid")?;
+        fs::write(backup_dir.join("auth.json"), "{}")?;
+        fs::write(backup_dir.join("cap_sid"), "sid")?;
+
+        scrub_temp_auth_material(temp.path())?;
+
+        assert!(!codex_home.exists());
+        Ok(())
     }
 }

--- a/src/app/auto_start.rs
+++ b/src/app/auto_start.rs
@@ -113,6 +113,12 @@ where
         let identity = codex::identity_from_snapshot(&snapshot)?;
         let (refreshed_snapshot, selected_model) =
             run_codex_usage_ping(&self.env, &snapshot, &identity)?;
+        let (_, current_snapshot) = self.repository.load_snapshot(&self.env.kind, account_id)?;
+        if current_snapshot != snapshot {
+            return Err(anyhow!(
+                "saved snapshot changed while ping was running; skipped write-back"
+            ));
+        }
         let refreshed_identity = codex::identity_from_snapshot(&refreshed_snapshot)?;
         self.repository.replace_snapshot(
             &self.env.kind,
@@ -188,8 +194,15 @@ fn run_codex_usage_ping(
     let work_dir =
         std::env::temp_dir().join(format!("codex-account-switcher-ping-{}", Uuid::new_v4()));
     let result = run_codex_usage_ping_in_temp_home(env, snapshot, identity, &work_dir);
-    let _ = fs::remove_dir_all(&work_dir);
-    result
+    let cleanup = remove_temp_auth_home(&work_dir);
+    match (result, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(error)) => Err(error),
+        (Err(error), Ok(())) => Err(error),
+        (Err(error), Err(cleanup_error)) => Err(error.context(format!(
+            "also failed to remove temporary auth home: {cleanup_error:#}"
+        ))),
+    }
 }
 
 fn run_codex_usage_ping_in_temp_home(
@@ -217,6 +230,13 @@ fn run_codex_usage_ping_in_temp_home(
     let mut command = Command::new("codex");
     command
         .env("CODEX_HOME", &temp_env.codex_root)
+        .env("HOME", &temp_env.home_dir)
+        .env("USERPROFILE", &temp_env.home_dir)
+        .env("APPDATA", temp_env.home_dir.join("AppData").join("Roaming"))
+        .env(
+            "LOCALAPPDATA",
+            temp_env.home_dir.join("AppData").join("Local"),
+        )
         .arg("exec")
         .arg("--ephemeral")
         .arg("--ignore-user-config")
@@ -251,6 +271,22 @@ fn run_codex_usage_ping_in_temp_home(
     let refreshed = codex::read_live_auth_bundle(&temp_env)
         .context("failed to read refreshed temporary Codex auth")?;
     Ok((refreshed.snapshot, selected_model))
+}
+
+fn remove_temp_auth_home(path: &Path) -> Result<()> {
+    for attempt in 0..5 {
+        match fs::remove_dir_all(path) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(_) if attempt < 4 => {
+                thread::sleep(StdDuration::from_millis(100));
+            }
+            Err(error) => {
+                return Err(error).with_context(|| format!("failed to remove {}", path.display()));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn run_command_with_timeout(command: &mut Command, timeout: StdDuration) -> Result<ExitStatus> {

--- a/src/app/auto_start.rs
+++ b/src/app/auto_start.rs
@@ -1,0 +1,370 @@
+use std::fs;
+use std::process::{Command, Stdio};
+use std::sync::OnceLock;
+use std::thread;
+use std::time::Duration as StdDuration;
+
+use anyhow::{Context, Result, anyhow};
+use serde_json::Value;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::codex;
+use crate::env;
+use crate::model::{
+    AutoStartUsageWindowAccountResult, AutoStartUsageWindowsRunOutput,
+    AutoStartUsageWindowsStatusOutput,
+};
+use crate::repository::SnapshotRepository;
+use crate::secrets::{MigratingSecretStore, SecretStore};
+use crate::settings::{load_settings, save_settings};
+
+use super::{App, saved_identity};
+
+pub const AUTO_START_USAGE_WINDOW_POLL_SECONDS: u64 = 300;
+
+const PING_INSTRUCTIONS: &str = "Reply only with ACK.";
+const PING_PROMPT: &str = "ACK";
+
+impl<S> App<S>
+where
+    S: SecretStore,
+{
+    pub fn auto_start_usage_windows_status(&self) -> Result<AutoStartUsageWindowsStatusOutput> {
+        let settings = load_settings(&self.env.app_data_dir)?;
+        Ok(auto_start_status_output(settings.auto_start_usage_windows))
+    }
+
+    pub fn set_auto_start_usage_windows(
+        &self,
+        enabled: bool,
+    ) -> Result<AutoStartUsageWindowsStatusOutput> {
+        let mut settings = load_settings(&self.env.app_data_dir)?;
+        settings.auto_start_usage_windows = enabled;
+        save_settings(&self.env.app_data_dir, &settings)?;
+        Ok(auto_start_status_output(enabled))
+    }
+
+    pub fn auto_start_usage_windows_once(
+        &self,
+        require_enabled: bool,
+    ) -> Result<AutoStartUsageWindowsRunOutput> {
+        let settings = load_settings(&self.env.app_data_dir)?;
+        let enabled = settings.auto_start_usage_windows;
+        let mut output = AutoStartUsageWindowsRunOutput {
+            enabled,
+            checked_accounts: 0,
+            selected_model: None,
+            pinged_accounts: Vec::new(),
+            skipped: Vec::new(),
+        };
+        if require_enabled && !enabled {
+            return Ok(output);
+        }
+
+        let accounts = self.repository.list_accounts(&self.env.kind)?;
+        output.checked_accounts = accounts.len();
+        let now = OffsetDateTime::now_utc();
+        let mut due_accounts = Vec::new();
+        for account in &accounts {
+            match self.usage(Some(account.id)) {
+                Ok(usage) => {
+                    if usage
+                        .usage
+                        .weekly
+                        .as_ref()
+                        .is_some_and(|weekly| usage_window_needs_ping(weekly.reset_at, now))
+                    {
+                        due_accounts.push((account.id, account.email.clone()));
+                    }
+                }
+                Err(error) => output
+                    .skipped
+                    .push(format!("{}: usage unavailable: {error:#}", account.email)),
+            }
+        }
+        if due_accounts.is_empty() {
+            return Ok(output);
+        }
+
+        let Some(original) = codex::try_read_live_auth_bundle(&self.env)? else {
+            output
+                .skipped
+                .push("no live account to restore after ping".to_owned());
+            return Ok(output);
+        };
+        let original_saved_account_id = accounts
+            .iter()
+            .find(|account| saved_identity(account).matches(&original.identity))
+            .map(|account| account.id);
+
+        let selected_model = best_available_mini_model();
+        output.selected_model = selected_model.clone();
+        for (account_id, email) in due_accounts {
+            let result =
+                match self.ping_usage_window_account(account_id, &email, selected_model.as_deref())
+                {
+                    Ok(result) => result,
+                    Err(error) => AutoStartUsageWindowAccountResult {
+                        account_id,
+                        email,
+                        status: "failed".to_owned(),
+                        detail: Some(format!("{error:#}")),
+                    },
+                };
+            output.pinged_accounts.push(result);
+        }
+
+        if let Some(account_id) = original_saved_account_id {
+            if let Err(error) = self.activate_with_running_policy(account_id, false) {
+                codex::restore_snapshot(&self.env, &original.snapshot, &original.identity, false)
+                    .with_context(|| {
+                    format!("failed to restore original account after activation failed: {error:#}")
+                })?;
+            }
+        } else {
+            codex::restore_snapshot(&self.env, &original.snapshot, &original.identity, false)
+                .context("failed to restore original account after usage-window ping")?;
+        }
+
+        Ok(output)
+    }
+
+    fn ping_usage_window_account(
+        &self,
+        account_id: Uuid,
+        email: &str,
+        selected_model: Option<&str>,
+    ) -> Result<AutoStartUsageWindowAccountResult> {
+        self.activate_with_running_policy(account_id, false)?;
+        run_codex_usage_ping(selected_model)?;
+        let saved = self.save_current()?;
+        let usage = self.usage(Some(saved.account.id))?;
+        let now = OffsetDateTime::now_utc();
+        let status = match usage.usage.weekly {
+            Some(weekly) if weekly.reset_at > now => "started",
+            Some(_) => "unchanged",
+            None => "usage_missing",
+        };
+        Ok(AutoStartUsageWindowAccountResult {
+            account_id,
+            email: email.to_owned(),
+            status: status.to_owned(),
+            detail: None,
+        })
+    }
+}
+
+pub fn spawn_auto_start_usage_windows_worker() {
+    static STARTED: OnceLock<()> = OnceLock::new();
+    STARTED.get_or_init(|| {
+        let _ = thread::Builder::new()
+            .name("auto-start-usage-windows".to_owned())
+            .spawn(|| {
+                loop {
+                    if let Err(error) = run_auto_start_usage_windows_for_detected_env() {
+                        eprintln!("auto-start usage-window check failed: {error:#}");
+                    }
+                    thread::sleep(StdDuration::from_secs(AUTO_START_USAGE_WINDOW_POLL_SECONDS));
+                }
+            });
+    });
+}
+
+fn run_auto_start_usage_windows_for_detected_env() -> Result<()> {
+    let env = env::detect()?;
+    let repository = SnapshotRepository::new(
+        &env.app_data_dir,
+        MigratingSecretStore::new(&env.app_data_dir.join("snapshots")),
+    );
+    let app = App::new(env, repository);
+    let _ = app.auto_start_usage_windows_once(true)?;
+    Ok(())
+}
+
+fn auto_start_status_output(enabled: bool) -> AutoStartUsageWindowsStatusOutput {
+    AutoStartUsageWindowsStatusOutput {
+        enabled,
+        poll_seconds: AUTO_START_USAGE_WINDOW_POLL_SECONDS,
+    }
+}
+
+fn usage_window_needs_ping(reset_at: OffsetDateTime, now: OffsetDateTime) -> bool {
+    reset_at <= now
+}
+
+fn run_codex_usage_ping(selected_model: Option<&str>) -> Result<()> {
+    let work_dir =
+        std::env::temp_dir().join(format!("codex-account-switcher-ping-{}", Uuid::new_v4()));
+    fs::create_dir_all(&work_dir)
+        .with_context(|| format!("failed to create {}", work_dir.display()))?;
+    let instruction_file = work_dir.join("instructions.md");
+    fs::write(&instruction_file, PING_INSTRUCTIONS)
+        .with_context(|| format!("failed to write {}", instruction_file.display()))?;
+
+    let mut command = Command::new("codex");
+    command
+        .arg("exec")
+        .arg("--ephemeral")
+        .arg("--ignore-user-config")
+        .arg("--ignore-rules")
+        .arg("--skip-git-repo-check")
+        .arg("--cd")
+        .arg(&work_dir)
+        .arg("-c")
+        .arg(format!(
+            "model_instructions_file={}",
+            toml_string_literal(&instruction_file.display().to_string())
+        ))
+        .arg("-c")
+        .arg("model_reasoning_effort=\"low\"");
+    if let Some(model) = selected_model {
+        command.arg("-m").arg(model);
+    }
+    command
+        .arg(PING_PROMPT)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    strip_codex_thread_env(&mut command);
+
+    let output = command.output();
+    let _ = fs::remove_dir_all(&work_dir);
+    let output = output.context("failed to run `codex exec`; make sure `codex` is on PATH")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(anyhow!(
+            "`codex exec` failed with {}: {detail}",
+            output.status
+        ));
+    }
+    Ok(())
+}
+
+fn strip_codex_thread_env(command: &mut Command) {
+    for key in ["CODEX_THREAD_ID", "CODEX_INTERNAL_ORIGINATOR_OVERRIDE"] {
+        command.env_remove(key);
+    }
+}
+
+fn best_available_mini_model() -> Option<String> {
+    for bundled in [false, true] {
+        let mut command = Command::new("codex");
+        command.arg("debug").arg("models");
+        if bundled {
+            command.arg("--bundled");
+        }
+        strip_codex_thread_env(&mut command);
+        let output = command.output().ok()?;
+        if !output.status.success() {
+            continue;
+        }
+        let raw = String::from_utf8_lossy(&output.stdout);
+        if let Some(model) = select_mini_model_from_catalog(&raw) {
+            return Some(model);
+        }
+    }
+    None
+}
+
+fn select_mini_model_from_catalog(raw: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(raw).ok()?;
+    let models = if let Some(models) = value.get("models").and_then(Value::as_array) {
+        models
+    } else {
+        value.as_array()?
+    };
+    let mut candidates = models
+        .iter()
+        .enumerate()
+        .filter_map(|(position, model)| {
+            let slug = model
+                .get("slug")
+                .or_else(|| model.get("id"))
+                .and_then(Value::as_str)?;
+            if !slug.ends_with("-mini")
+                || model.get("supported_in_api").and_then(Value::as_bool) == Some(false)
+            {
+                return None;
+            }
+            let priority = model
+                .get("priority")
+                .and_then(Value::as_i64)
+                .unwrap_or(i64::MAX);
+            Some((priority, position, slug.to_owned()))
+        })
+        .collect::<Vec<_>>();
+    candidates.sort_by_key(|(priority, position, _)| (*priority, *position));
+    candidates.into_iter().map(|(_, _, slug)| slug).next()
+}
+
+fn toml_string_literal(value: &str) -> String {
+    let mut literal = String::from("\"");
+    for character in value.chars() {
+        match character {
+            '\\' => literal.push_str("\\\\"),
+            '"' => literal.push_str("\\\""),
+            '\n' => literal.push_str("\\n"),
+            '\r' => literal.push_str("\\r"),
+            '\t' => literal.push_str("\\t"),
+            other => literal.push(other),
+        }
+    }
+    literal.push('"');
+    literal
+}
+
+#[cfg(test)]
+mod tests {
+    use time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn usage_window_needs_ping_when_reset_is_due_or_past() {
+        let now = OffsetDateTime::now_utc();
+
+        assert!(usage_window_needs_ping(now, now));
+        assert!(usage_window_needs_ping(now - Duration::minutes(1), now));
+        assert!(!usage_window_needs_ping(now + Duration::minutes(1), now));
+    }
+
+    #[test]
+    fn mini_model_selector_prefers_lowest_priority_available_mini() {
+        let raw = r#"{
+          "models": [
+            {"slug": "gpt-5.5", "priority": 1, "supported_in_api": true},
+            {"slug": "gpt-5.3-mini", "priority": 20, "supported_in_api": true},
+            {"slug": "gpt-5.4-mini", "priority": 10, "supported_in_api": true}
+          ]
+        }"#;
+
+        assert_eq!(
+            select_mini_model_from_catalog(raw).as_deref(),
+            Some("gpt-5.4-mini")
+        );
+    }
+
+    #[test]
+    fn mini_model_selector_skips_api_unsupported_models() {
+        let raw = r#"[
+          {"slug": "gpt-hidden-mini", "priority": 1, "supported_in_api": false},
+          {"slug": "gpt-visible-mini", "priority": 2, "supported_in_api": true}
+        ]"#;
+
+        assert_eq!(
+            select_mini_model_from_catalog(raw).as_deref(),
+            Some("gpt-visible-mini")
+        );
+    }
+
+    #[test]
+    fn toml_string_literal_escapes_windows_paths() {
+        assert_eq!(
+            toml_string_literal(r#"C:\Temp\codex "ping"\instructions.md"#),
+            r#""C:\\Temp\\codex \"ping\"\\instructions.md""#
+        );
+    }
+}

--- a/src/app/auto_start.rs
+++ b/src/app/auto_start.rs
@@ -154,6 +154,10 @@ pub fn spawn_auto_start_usage_windows_worker() {
     });
 }
 
+pub(crate) fn run_auto_start_usage_windows_check_now() -> Result<()> {
+    run_auto_start_usage_windows_for_detected_env()
+}
+
 fn run_auto_start_usage_windows_for_detected_env() -> Result<()> {
     let env = env::detect()?;
     let repository = SnapshotRepository::new(

--- a/src/app/auto_start.rs
+++ b/src/app/auto_start.rs
@@ -219,9 +219,25 @@ fn run_codex_usage_ping(
             })
         }
         (Err(error), Ok(())) => Err(error),
-        (Err(error), Err(cleanup_error)) => Err(error.context(format!(
-            "also failed to remove temporary auth home: {cleanup_error:#}"
-        ))),
+        (Err(error), Err(cleanup_error)) => {
+            let mut combined = error.context(format!(
+                "also failed to remove temporary auth home: {cleanup_error:#}"
+            ));
+            match scrub_temp_auth_material(&work_dir) {
+                Ok(()) => {
+                    if let Err(final_error) = remove_temp_auth_home(&work_dir) {
+                        combined = combined.context(format!(
+                            "temporary auth scrub succeeded but final cleanup failed: {final_error:#}"
+                        ));
+                    }
+                }
+                Err(scrub_error) => {
+                    combined =
+                        combined.context(format!("temporary auth scrub failed: {scrub_error:#}"));
+                }
+            }
+            Err(combined)
+        }
     }
 }
 

--- a/src/app/auto_start.rs
+++ b/src/app/auto_start.rs
@@ -156,6 +156,7 @@ pub fn spawn_auto_start_usage_windows_worker() {
     });
 }
 
+#[cfg(windows)]
 pub(crate) fn run_auto_start_usage_windows_check_now() -> Result<()> {
     run_auto_start_usage_windows_for_detected_env()
 }

--- a/src/app/auto_start.rs
+++ b/src/app/auto_start.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 use std::process::{Command, ExitStatus, Stdio};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration as StdDuration, Instant};
 
@@ -10,7 +10,7 @@ use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::codex;
-use crate::env::{self, AppEnv};
+use crate::env::AppEnv;
 use crate::model::{
     AUTH_FILES, AutoStartUsageWindowAccountResult, AutoStartUsageWindowsRunOutput,
     AutoStartUsageWindowsStatusOutput, DisplayIdentity, SnapshotBlob,
@@ -61,6 +61,10 @@ where
             return Ok(output);
         }
 
+        let _run_guard = AUTO_START_RUN_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .map_err(|_| anyhow!("auto-start usage-window run lock poisoned"))?;
         let accounts = self.repository.list_accounts(&self.env.kind)?;
         output.checked_accounts = accounts.len();
         let now = OffsetDateTime::now_utc();
@@ -110,7 +114,8 @@ where
         let (_, snapshot) = self.repository.load_snapshot(&self.env.kind, account_id)?;
         let identity = codex::identity_from_snapshot(&snapshot)?;
         let ping_result = run_codex_usage_ping(&self.env, &snapshot, &identity)?;
-        let (_, current_snapshot) = self.repository.load_snapshot(&self.env.kind, account_id)?;
+        let (current_metadata, current_snapshot) =
+            self.repository.load_snapshot(&self.env.kind, account_id)?;
         if current_snapshot != snapshot {
             return Err(anyhow!(
                 "saved snapshot changed while ping was running; skipped write-back"
@@ -122,7 +127,7 @@ where
             account_id,
             &refreshed_identity,
             &ping_result.snapshot,
-            None,
+            current_metadata.cached_usage,
         )?;
         let usage = self.usage(Some(account_id))?;
         let now = OffsetDateTime::now_utc();
@@ -140,14 +145,16 @@ where
     }
 }
 
-pub fn spawn_auto_start_usage_windows_worker() {
+static AUTO_START_RUN_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+pub fn spawn_auto_start_usage_windows_worker(env: AppEnv) {
     static STARTED: OnceLock<()> = OnceLock::new();
-    STARTED.get_or_init(|| {
+    STARTED.get_or_init(move || {
         let _ = thread::Builder::new()
             .name("auto-start-usage-windows".to_owned())
-            .spawn(|| {
+            .spawn(move || {
                 loop {
-                    if let Err(error) = run_auto_start_usage_windows_for_detected_env() {
+                    if let Err(error) = run_auto_start_usage_windows_for_env(env.clone()) {
                         eprintln!("auto-start usage-window check failed: {error:#}");
                     }
                     thread::sleep(StdDuration::from_secs(AUTO_START_USAGE_WINDOW_POLL_SECONDS));
@@ -157,12 +164,11 @@ pub fn spawn_auto_start_usage_windows_worker() {
 }
 
 #[cfg(windows)]
-pub(crate) fn run_auto_start_usage_windows_check_now() -> Result<()> {
-    run_auto_start_usage_windows_for_detected_env()
+pub(crate) fn run_auto_start_usage_windows_check_now(env: AppEnv) -> Result<()> {
+    run_auto_start_usage_windows_for_env(env)
 }
 
-fn run_auto_start_usage_windows_for_detected_env() -> Result<()> {
-    let env = env::detect()?;
+fn run_auto_start_usage_windows_for_env(env: AppEnv) -> Result<()> {
     let repository = SnapshotRepository::new(
         &env.app_data_dir,
         MigratingSecretStore::new(&env.app_data_dir.join("snapshots")),

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -13,8 +13,8 @@ use crate::secrets::SecretStore;
 use crate::usage::{fetch_usage, usage_target_from_snapshot};
 
 use super::{
-    App, account_view, match_saved_account, saved_identity, should_verify_activation_stability,
-    subject_bound_identity_matches,
+    App, account_view, auth_mutation_lock, match_saved_account, saved_identity,
+    should_verify_activation_stability, subject_bound_identity_matches,
 };
 
 impl<S> App<S>
@@ -59,6 +59,11 @@ where
     }
 
     pub fn save_current(&self) -> Result<SaveOutput> {
+        let _guard = auth_mutation_lock();
+        self.save_current_unlocked()
+    }
+
+    pub(super) fn save_current_unlocked(&self) -> Result<SaveOutput> {
         let live = codex::read_live_auth_bundle(&self.env).with_context(|| {
             format!(
                 "no live Codex auth bundle found at {}",
@@ -92,8 +97,9 @@ where
         account_id: Uuid,
         force_running: bool,
     ) -> Result<ActivateOutput> {
+        let _guard = auth_mutation_lock();
         let warnings = crate::process::detect_running_codex_processes();
-        self.refresh_current_saved_account_before_activation();
+        self.refresh_current_saved_account_before_activation_unlocked();
         let (snapshot, snapshot_identity, restore_identity) =
             self.load_activation_target(account_id)?;
         let verify_stable = should_verify_activation_stability(force_running, &warnings);
@@ -109,7 +115,7 @@ where
         })
     }
 
-    fn refresh_current_saved_account_before_activation(&self) {
+    fn refresh_current_saved_account_before_activation_unlocked(&self) {
         let Ok(saved_accounts) = self.repository.list_accounts(&self.env.kind) else {
             return;
         };
@@ -119,13 +125,13 @@ where
         let Some(_current_saved) = match_saved_account(&saved_accounts, &live.identity) else {
             return;
         };
-        let Ok(saved) = self.save_current() else {
+        let Ok(saved) = self.save_current_unlocked() else {
             return;
         };
         let _ = self.usage(Some(saved.account.id));
     }
 
-    fn load_activation_target(
+    pub(super) fn load_activation_target(
         &self,
         account_id: Uuid,
     ) -> Result<(SnapshotBlob, DisplayIdentity, DisplayIdentity)> {

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -25,6 +25,10 @@ where
         Self { env, repository }
     }
 
+    pub(crate) fn env(&self) -> &AppEnv {
+        &self.env
+    }
+
     pub fn status(&self) -> Result<StatusOutput> {
         let saved_accounts = self.repository.list_accounts(&self.env.kind)?;
         let live = codex::try_read_live_auth_bundle(&self.env)?;

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -13,8 +13,8 @@ use crate::secrets::SecretStore;
 use crate::usage::{fetch_usage, usage_target_from_snapshot};
 
 use super::{
-    App, account_view, auth_mutation_lock, match_saved_account, saved_identity,
-    should_verify_activation_stability, subject_bound_identity_matches,
+    App, account_view, match_saved_account, saved_identity, should_verify_activation_stability,
+    subject_bound_identity_matches,
 };
 
 impl<S> App<S>
@@ -59,11 +59,6 @@ where
     }
 
     pub fn save_current(&self) -> Result<SaveOutput> {
-        let _guard = auth_mutation_lock();
-        self.save_current_unlocked()
-    }
-
-    pub(super) fn save_current_unlocked(&self) -> Result<SaveOutput> {
         let live = codex::read_live_auth_bundle(&self.env).with_context(|| {
             format!(
                 "no live Codex auth bundle found at {}",
@@ -97,9 +92,8 @@ where
         account_id: Uuid,
         force_running: bool,
     ) -> Result<ActivateOutput> {
-        let _guard = auth_mutation_lock();
         let warnings = crate::process::detect_running_codex_processes();
-        self.refresh_current_saved_account_before_activation_unlocked();
+        self.refresh_current_saved_account_before_activation();
         let (snapshot, snapshot_identity, restore_identity) =
             self.load_activation_target(account_id)?;
         let verify_stable = should_verify_activation_stability(force_running, &warnings);
@@ -115,7 +109,7 @@ where
         })
     }
 
-    fn refresh_current_saved_account_before_activation_unlocked(&self) {
+    fn refresh_current_saved_account_before_activation(&self) {
         let Ok(saved_accounts) = self.repository.list_accounts(&self.env.kind) else {
             return;
         };
@@ -125,13 +119,13 @@ where
         let Some(_current_saved) = match_saved_account(&saved_accounts, &live.identity) else {
             return;
         };
-        let Ok(saved) = self.save_current_unlocked() else {
+        let Ok(saved) = self.save_current() else {
             return;
         };
         let _ = self.usage(Some(saved.account.id));
     }
 
-    pub(super) fn load_activation_target(
+    fn load_activation_target(
         &self,
         account_id: Uuid,
     ) -> Result<(SnapshotBlob, DisplayIdentity, DisplayIdentity)> {

--- a/src/app/tui.rs
+++ b/src/app/tui.rs
@@ -4,7 +4,10 @@ use dialoguer::{Select, theme::ColorfulTheme};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
-use crate::model::{AccountView, ListOutput, RunningCodexProcess, SaveAction, StatusOutput};
+use crate::model::{
+    AccountView, AutoStartUsageWindowsRunOutput, ListOutput, RunningCodexProcess, SaveAction,
+    StatusOutput,
+};
 use crate::process::format_process_table;
 use crate::secrets::SecretStore;
 
@@ -33,16 +36,28 @@ where
                     .find(|account| account_view_matches_identity(account, identity))
                     .map(|account| account.id)
             });
+            let auto_start_usage_windows_enabled = matches!(mode, InteractiveMode::Persistent)
+                && self.auto_start_usage_windows_status()?.enabled;
 
-            let menu = build_menu(mode, &status, &list, current_saved);
+            let menu = build_menu(
+                mode,
+                &status,
+                &list,
+                current_saved,
+                auto_start_usage_windows_enabled,
+            );
             let selection = match mode {
                 InteractiveMode::Persistent => {
                     select_persistent_entry(&menu, default_selection, &feedback)?
                 }
                 InteractiveMode::ActivateOnce | InteractiveMode::DeleteOnce => {
                     let labels = menu.labels();
-                    Select::with_theme(&ColorfulTheme::default())
-                        .with_prompt(menu.prompt)
+                    let theme = ColorfulTheme::default();
+                    let mut select = Select::with_theme(&theme);
+                    if !menu.prompt.is_empty() {
+                        select = select.with_prompt(menu.prompt);
+                    }
+                    select
                         .items(&labels)
                         .default(default_selection.min(menu.len().saturating_sub(1)))
                         .interact()?
@@ -178,6 +193,34 @@ where
                 InteractiveAction::ShowStatus => {
                     feedback = interactive_status_lines(&status);
                 }
+                InteractiveAction::SetAutoStartUsageWindows(enabled) => {
+                    match self.set_auto_start_usage_windows(enabled) {
+                        Ok(output) => feedback.push(format!(
+                            "Auto-start usage windows {}.",
+                            if output.enabled {
+                                "enabled"
+                            } else {
+                                "disabled"
+                            }
+                        )),
+                        Err(error) => {
+                            feedback =
+                                error_feedback("Updating auto-start usage windows failed.", error);
+                            continue;
+                        }
+                    }
+                    if enabled {
+                        match self.auto_start_usage_windows_once(true) {
+                            Ok(output) => {
+                                feedback.extend(auto_start_usage_window_feedback(&output))
+                            }
+                            Err(error) => {
+                                feedback =
+                                    error_feedback("Auto-start usage window check failed.", error);
+                            }
+                        }
+                    }
+                }
                 #[cfg(windows)]
                 InteractiveAction::SendToTray => return Ok(InteractiveExit::SendToTray),
                 InteractiveAction::Quit => break,
@@ -194,6 +237,7 @@ pub(crate) enum InteractiveAction {
     Delete(Uuid),
     DeletePrompt,
     ShowStatus,
+    SetAutoStartUsageWindows(bool),
     #[cfg(windows)]
     SendToTray,
     Quit,
@@ -343,6 +387,7 @@ pub(crate) fn build_menu(
     status: &StatusOutput,
     list: &ListOutput,
     current_saved: Option<Uuid>,
+    auto_start_usage_windows_enabled: bool,
 ) -> InteractiveMenu {
     let active_account = current_saved
         .and_then(|saved_id| list.accounts.iter().find(|account| account.id == saved_id));
@@ -409,6 +454,14 @@ pub(crate) fn build_menu(
             });
         }
         actions.push(InteractiveItem {
+            label: if auto_start_usage_windows_enabled {
+                "Disable auto-start usage windows".to_owned()
+            } else {
+                "Enable auto-start usage windows".to_owned()
+            },
+            action: InteractiveAction::SetAutoStartUsageWindows(!auto_start_usage_windows_enabled),
+        });
+        actions.push(InteractiveItem {
             label: "Show status".to_owned(),
             action: InteractiveAction::ShowStatus,
         });
@@ -424,9 +477,7 @@ pub(crate) fn build_menu(
     });
 
     let prompt = match mode {
-        InteractiveMode::Persistent | InteractiveMode::ActivateOnce => {
-            "Which account do you want to activate?"
-        }
+        InteractiveMode::Persistent | InteractiveMode::ActivateOnce => "",
         InteractiveMode::DeleteOnce => "Which saved account do you want to delete?",
     };
 
@@ -513,8 +564,10 @@ fn render_persistent_menu(
         term.write_line("")?;
         lines += 1;
     }
-    term.write_line(&style(menu.prompt).bold().to_string())?;
-    lines += 1;
+    if !menu.prompt.is_empty() {
+        term.write_line(&style(menu.prompt).bold().to_string())?;
+        lines += 1;
+    }
     term.write_line(&render_section_heading("Active Account"))?;
     lines += 1;
     if let Some(current_status_label) = &menu.current_status_label {
@@ -688,6 +741,26 @@ fn interactive_status_lines(status: &StatusOutput) -> Vec<String> {
 fn process_summary_lines(title: &str, processes: &[RunningCodexProcess]) -> Vec<String> {
     let mut lines = vec![format!("{title}:")];
     lines.extend(format_process_table(processes));
+    lines
+}
+
+fn auto_start_usage_window_feedback(output: &AutoStartUsageWindowsRunOutput) -> Vec<String> {
+    let mut lines = vec![format!(
+        "Checked {} saved accounts for due weekly windows.",
+        output.checked_accounts
+    )];
+    if output.pinged_accounts.is_empty() && output.skipped.is_empty() {
+        lines.push("No due weekly windows found.".to_owned());
+    }
+    for account in &output.pinged_accounts {
+        lines.push(match &account.detail {
+            Some(detail) => format!("{}: {} ({detail})", account.email, account.status),
+            None => format!("{}: {}", account.email, account.status),
+        });
+    }
+    for skipped in &output.skipped {
+        lines.push(format!("Skipped: {skipped}"));
+    }
     lines
 }
 
@@ -875,7 +948,9 @@ mod tests {
             &sample_status(Some(id)),
             &sample_list(id, true),
             Some(id),
+            false,
         );
+        assert_eq!(menu.prompt, "");
         assert_eq!(menu.accounts.len(), 0);
         assert_eq!(menu.len(), 1);
         assert!(matches!(menu.action(0), InteractiveAction::Quit));
@@ -889,6 +964,7 @@ mod tests {
             &sample_status(Some(id)),
             &sample_list(id, true),
             Some(id),
+            false,
         );
         assert_eq!(menu.prompt, "Which saved account do you want to delete?");
         assert_eq!(menu.len(), 2);
@@ -905,6 +981,7 @@ mod tests {
             &sample_status(Some(id)),
             &sample_list(id, false),
             Some(id),
+            false,
         );
         assert_eq!(menu.accounts.len(), 1);
         assert!(matches!(menu.action(1), InteractiveAction::SaveCurrent));
@@ -912,6 +989,44 @@ mod tests {
             menu.actions[0].label,
             "Refresh saved snapshot for person@example.com"
         );
+    }
+
+    #[test]
+    fn persistent_menu_shows_auto_start_usage_window_toggle() {
+        let id = Uuid::new_v4();
+        let disabled_menu = build_menu(
+            InteractiveMode::Persistent,
+            &sample_status(Some(id)),
+            &sample_list(id, false),
+            Some(id),
+            false,
+        );
+        let disabled_toggle = disabled_menu
+            .actions
+            .iter()
+            .find(|item| item.label == "Enable auto-start usage windows")
+            .expect("enable toggle");
+        assert!(matches!(
+            disabled_toggle.action,
+            InteractiveAction::SetAutoStartUsageWindows(true)
+        ));
+
+        let enabled_menu = build_menu(
+            InteractiveMode::Persistent,
+            &sample_status(Some(id)),
+            &sample_list(id, false),
+            Some(id),
+            true,
+        );
+        let enabled_toggle = enabled_menu
+            .actions
+            .iter()
+            .find(|item| item.label == "Disable auto-start usage windows")
+            .expect("disable toggle");
+        assert!(matches!(
+            enabled_toggle.action,
+            InteractiveAction::SetAutoStartUsageWindows(false)
+        ));
     }
 
     #[test]
@@ -937,6 +1052,7 @@ mod tests {
             &sample_status(Some(id)),
             &sample_list(id, false),
             Some(id),
+            false,
         );
         assert_eq!(jump_section(&menu, 0), 1);
         assert_eq!(jump_section(&menu, 1), 0);
@@ -950,6 +1066,7 @@ mod tests {
             &sample_status(Some(id)),
             &sample_list(id, true),
             Some(id),
+            false,
         );
         assert_eq!(menu.accounts.len(), 0);
         let current = menu
@@ -987,6 +1104,7 @@ mod tests {
             &status,
             &sample_list(id, false),
             None,
+            false,
         );
         assert_eq!(
             menu.current_status_label.as_deref(),
@@ -1036,7 +1154,7 @@ mod tests {
         let app = App::new(env, repo);
         let status = app.status().expect("status");
         let list = app.list().expect("list");
-        let menu = build_menu(InteractiveMode::Persistent, &status, &list, None);
+        let menu = build_menu(InteractiveMode::Persistent, &status, &list, None, false);
         assert_eq!(menu.accounts.len(), 1);
         assert!(menu.actions.iter().any(|item| item.label == "Show status"));
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -216,7 +216,7 @@ fn run_interactive_app<S>(app: &App<S>) -> Result<()>
 where
     S: crate::secrets::SecretStore,
 {
-    crate::app::spawn_auto_start_usage_windows_worker();
+    crate::app::spawn_auto_start_usage_windows_worker(app.env().clone());
     #[cfg(windows)]
     {
         loop {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -305,16 +305,9 @@ fn print_auto_start_usage_windows_run(output: &AutoStartUsageWindowsRunOutput) {
     );
     println!("Checked accounts: {}", output.checked_accounts);
     for account in &output.pinged_accounts {
-        match (&account.selected_model, &account.detail) {
-            (Some(model), Some(detail)) => {
-                println!(
-                    "{}: {} via {model} ({detail})",
-                    account.email, account.status
-                )
-            }
-            (Some(model), None) => println!("{}: {} via {model}", account.email, account.status),
-            (None, Some(detail)) => println!("{}: {} ({detail})", account.email, account.status),
-            (None, None) => println!("{}: {}", account.email, account.status),
+        match &account.detail {
+            Some(detail) => println!("{}: {} ({detail})", account.email, account.status),
+            None => println!("{}: {}", account.email, account.status),
         }
     }
     for skipped in &output.skipped {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,10 @@ use uuid::Uuid;
 
 use crate::app::{App, InteractiveExit, InteractiveMode};
 use crate::env;
-use crate::model::{AccountUsageView, AccountView, RunningCodexProcess, UsageOutput};
+use crate::model::{
+    AccountUsageView, AccountView, AutoStartUsageWindowsRunOutput,
+    AutoStartUsageWindowsStatusOutput, RunningCodexProcess, UsageOutput,
+};
 use crate::process::format_process_table;
 use crate::repository::SnapshotRepository;
 use crate::secrets::MigratingSecretStore;
@@ -49,6 +52,16 @@ enum Command {
     },
     Delete {
         account_id: Option<Uuid>,
+        #[arg(long)]
+        json: bool,
+    },
+    AutoStartUsageWindows {
+        #[arg(long, conflicts_with = "disable")]
+        enable: bool,
+        #[arg(long)]
+        disable: bool,
+        #[arg(long)]
+        run: bool,
         #[arg(long)]
         json: bool,
     },
@@ -169,6 +182,33 @@ pub fn run() -> Result<()> {
             }
             Ok(())
         }
+        Some(Command::AutoStartUsageWindows {
+            enable,
+            disable,
+            run,
+            json,
+        }) => {
+            let status = if enable {
+                app.set_auto_start_usage_windows(true)?
+            } else if disable {
+                app.set_auto_start_usage_windows(false)?
+            } else {
+                app.auto_start_usage_windows_status()?
+            };
+            if run {
+                let output = app.auto_start_usage_windows_once(true)?;
+                if json {
+                    print_json(&output)?;
+                } else {
+                    print_auto_start_usage_windows_run(&output);
+                }
+            } else if json {
+                print_json(&status)?;
+            } else {
+                print_auto_start_usage_windows_status(&status);
+            }
+            Ok(())
+        }
     }
 }
 
@@ -176,6 +216,7 @@ fn run_interactive_app<S>(app: &App<S>) -> Result<()>
 where
     S: crate::secrets::SecretStore,
 {
+    crate::app::spawn_auto_start_usage_windows_worker();
     loop {
         match app.interactive(InteractiveMode::Persistent, false)? {
             InteractiveExit::Quit => return Ok(()),
@@ -239,6 +280,42 @@ fn print_usage_output(output: &UsageOutput) {
         println!("Plan: {plan}");
     }
     print_usage_summary(&output.usage);
+}
+
+fn print_auto_start_usage_windows_status(output: &AutoStartUsageWindowsStatusOutput) {
+    println!(
+        "Auto-start usage windows: {}",
+        if output.enabled {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    );
+    println!("Poll interval: {}s", output.poll_seconds);
+}
+
+fn print_auto_start_usage_windows_run(output: &AutoStartUsageWindowsRunOutput) {
+    println!(
+        "Auto-start usage windows: {}",
+        if output.enabled {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    );
+    println!("Checked accounts: {}", output.checked_accounts);
+    if let Some(model) = &output.selected_model {
+        println!("Model: {model}");
+    }
+    for account in &output.pinged_accounts {
+        match &account.detail {
+            Some(detail) => println!("{}: {} ({detail})", account.email, account.status),
+            None => println!("{}: {}", account.email, account.status),
+        }
+    }
+    for skipped in &output.skipped {
+        println!("Skipped: {skipped}");
+    }
 }
 
 fn print_usage_summary(usage: &AccountUsageView) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -195,7 +195,7 @@ pub fn run() -> Result<()> {
             } else {
                 app.auto_start_usage_windows_status()?
             };
-            if run {
+            if run && !disable {
                 let output = app.auto_start_usage_windows_once(false)?;
                 if json {
                     print_json(&output)?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -217,17 +217,25 @@ where
     S: crate::secrets::SecretStore,
 {
     crate::app::spawn_auto_start_usage_windows_worker();
-    loop {
-        match app.interactive(InteractiveMode::Persistent, false)? {
-            InteractiveExit::Quit => return Ok(()),
-            #[cfg(windows)]
-            InteractiveExit::SendToTray => {
-                crate::tray::hide_console_window();
-                match crate::tray::run(app)? {
-                    crate::tray::TrayExit::ShowTui => crate::tray::show_console_window(),
-                    crate::tray::TrayExit::Quit => return Ok(()),
+    #[cfg(windows)]
+    {
+        loop {
+            match app.interactive(InteractiveMode::Persistent, false)? {
+                InteractiveExit::Quit => return Ok(()),
+                InteractiveExit::SendToTray => {
+                    crate::tray::hide_console_window();
+                    match crate::tray::run(app)? {
+                        crate::tray::TrayExit::ShowTui => crate::tray::show_console_window(),
+                        crate::tray::TrayExit::Quit => return Ok(()),
+                    }
                 }
             }
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        match app.interactive(InteractiveMode::Persistent, false)? {
+            InteractiveExit::Quit => Ok(()),
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -196,7 +196,7 @@ pub fn run() -> Result<()> {
                 app.auto_start_usage_windows_status()?
             };
             if run {
-                let output = app.auto_start_usage_windows_once(true)?;
+                let output = app.auto_start_usage_windows_once(false)?;
                 if json {
                     print_json(&output)?;
                 } else {
@@ -304,13 +304,17 @@ fn print_auto_start_usage_windows_run(output: &AutoStartUsageWindowsRunOutput) {
         }
     );
     println!("Checked accounts: {}", output.checked_accounts);
-    if let Some(model) = &output.selected_model {
-        println!("Model: {model}");
-    }
     for account in &output.pinged_accounts {
-        match &account.detail {
-            Some(detail) => println!("{}: {} ({detail})", account.email, account.status),
-            None => println!("{}: {}", account.email, account.status),
+        match (&account.selected_model, &account.detail) {
+            (Some(model), Some(detail)) => {
+                println!(
+                    "{}: {} via {model} ({detail})",
+                    account.email, account.status
+                )
+            }
+            (Some(model), None) => println!("{}: {} via {model}", account.email, account.status),
+            (None, Some(detail)) => println!("{}: {} ({detail})", account.email, account.status),
+            (None, None) => println!("{}: {}", account.email, account.status),
         }
     }
     for skipped in &output.skipped {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod model;
 pub mod process;
 pub mod repository;
 pub mod secrets;
+pub mod settings;
 #[cfg(windows)]
 pub mod tray;
 pub mod usage;

--- a/src/model.rs
+++ b/src/model.rs
@@ -153,6 +153,29 @@ pub struct UsageOutput {
 }
 
 #[derive(Clone, Debug, Serialize)]
+pub struct AutoStartUsageWindowsStatusOutput {
+    pub enabled: bool,
+    pub poll_seconds: u64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct AutoStartUsageWindowsRunOutput {
+    pub enabled: bool,
+    pub checked_accounts: usize,
+    pub selected_model: Option<String>,
+    pub pinged_accounts: Vec<AutoStartUsageWindowAccountResult>,
+    pub skipped: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct AutoStartUsageWindowAccountResult {
+    pub account_id: Uuid,
+    pub email: String,
+    pub status: String,
+    pub detail: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
 pub struct SaveOutput {
     pub account: AccountView,
     pub action: SaveAction,

--- a/src/model.rs
+++ b/src/model.rs
@@ -171,7 +171,6 @@ pub struct AutoStartUsageWindowAccountResult {
     pub account_id: Uuid,
     pub email: String,
     pub status: String,
-    pub selected_model: Option<String>,
     pub detail: Option<String>,
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -162,7 +162,6 @@ pub struct AutoStartUsageWindowsStatusOutput {
 pub struct AutoStartUsageWindowsRunOutput {
     pub enabled: bool,
     pub checked_accounts: usize,
-    pub selected_model: Option<String>,
     pub pinged_accounts: Vec<AutoStartUsageWindowAccountResult>,
     pub skipped: Vec<String>,
 }
@@ -172,6 +171,7 @@ pub struct AutoStartUsageWindowAccountResult {
     pub account_id: Uuid,
     pub email: String,
     pub status: String,
+    pub selected_model: Option<String>,
     pub detail: Option<String>,
 }
 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -41,7 +41,7 @@ where
             .into_iter()
             .filter(|account| &account.environment == environment)
             .collect::<Vec<_>>();
-        accounts.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+        accounts.sort_by_key(|account| std::cmp::Reverse(account.updated_at));
         Ok(accounts)
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+use crate::file_store::replace_file_with_recovery;
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AppSettings {
     #[serde(default)]
@@ -13,8 +15,7 @@ pub struct AppSettings {
 pub fn load_settings(app_data_dir: &Path) -> Result<AppSettings> {
     let path = settings_path(app_data_dir);
     match fs::read(&path) {
-        Ok(bytes) => serde_json::from_slice(&bytes)
-            .with_context(|| format!("failed to parse {}", path.display())),
+        Ok(bytes) => Ok(serde_json::from_slice(&bytes).unwrap_or_default()),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(AppSettings::default()),
         Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
     }
@@ -25,7 +26,10 @@ pub fn save_settings(app_data_dir: &Path, settings: &AppSettings) -> Result<()> 
         .with_context(|| format!("failed to create {}", app_data_dir.display()))?;
     let path = settings_path(app_data_dir);
     let bytes = serde_json::to_vec_pretty(settings).context("failed to encode settings")?;
-    fs::write(&path, bytes).with_context(|| format!("failed to write {}", path.display()))?;
+    replace_file_with_recovery(&path, Some(&bytes), |temp_path| {
+        fs::write(temp_path, &bytes)
+            .with_context(|| format!("failed to write {}", temp_path.display()))
+    })?;
     Ok(())
 }
 
@@ -62,5 +66,16 @@ mod tests {
         let settings = load_settings(temp.path()).expect("load settings");
 
         assert!(settings.auto_start_usage_windows);
+    }
+
+    #[test]
+    fn malformed_settings_default_to_disabled() {
+        let temp = tempdir().expect("tempdir");
+        std::fs::create_dir_all(temp.path()).expect("settings dir");
+        std::fs::write(settings_path(temp.path()), "{").expect("settings file");
+
+        let settings = load_settings(temp.path()).expect("load settings");
+
+        assert!(!settings.auto_start_usage_windows);
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,66 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AppSettings {
+    #[serde(default)]
+    pub auto_start_usage_windows: bool,
+}
+
+pub fn load_settings(app_data_dir: &Path) -> Result<AppSettings> {
+    let path = settings_path(app_data_dir);
+    match fs::read(&path) {
+        Ok(bytes) => serde_json::from_slice(&bytes)
+            .with_context(|| format!("failed to parse {}", path.display())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(AppSettings::default()),
+        Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
+    }
+}
+
+pub fn save_settings(app_data_dir: &Path, settings: &AppSettings) -> Result<()> {
+    fs::create_dir_all(app_data_dir)
+        .with_context(|| format!("failed to create {}", app_data_dir.display()))?;
+    let path = settings_path(app_data_dir);
+    let bytes = serde_json::to_vec_pretty(settings).context("failed to encode settings")?;
+    fs::write(&path, bytes).with_context(|| format!("failed to write {}", path.display()))?;
+    Ok(())
+}
+
+fn settings_path(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join("settings.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn missing_settings_default_to_disabled() {
+        let temp = tempdir().expect("tempdir");
+
+        let settings = load_settings(temp.path()).expect("load settings");
+
+        assert!(!settings.auto_start_usage_windows);
+    }
+
+    #[test]
+    fn saved_settings_round_trip() {
+        let temp = tempdir().expect("tempdir");
+        save_settings(
+            temp.path(),
+            &AppSettings {
+                auto_start_usage_windows: true,
+            },
+        )
+        .expect("save settings");
+
+        let settings = load_settings(temp.path()).expect("load settings");
+
+        assert!(settings.auto_start_usage_windows);
+    }
+}

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -131,11 +131,12 @@ where
                     eprintln!("failed to update auto-start usage windows from tray: {error:#}");
                 } else if enabled {
                     let proxy = self.event_proxy.clone();
+                    let env = self.app.env().clone();
                     let _ = thread::Builder::new()
                         .name("tray-auto-start-usage-windows".to_owned())
                         .spawn(move || {
                             if let Err(error) =
-                                crate::app::run_auto_start_usage_windows_check_now()
+                                crate::app::run_auto_start_usage_windows_check_now(env)
                             {
                                 eprintln!(
                                     "failed to run auto-start usage window check from tray: {error:#}"

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::thread;
 
 use anyhow::{Context, Result};
 use time::OffsetDateTime;
@@ -8,7 +9,7 @@ use tray_icon::{Icon, TrayIcon, TrayIconBuilder};
 use uuid::Uuid;
 use winit::application::ApplicationHandler;
 use winit::event::WindowEvent;
-use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
 use winit::window::WindowId;
 
 use crate::app::App;
@@ -18,6 +19,7 @@ use crate::secrets::SecretStore;
 #[derive(Debug)]
 enum UserEvent {
     Menu(MenuEvent),
+    AutoStartUsageWindowsChecked,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -38,6 +40,7 @@ struct TrayState<'a, S> {
     app: &'a App<S>,
     tray_icon: Option<TrayIcon>,
     commands: HashMap<String, TrayCommand>,
+    event_proxy: EventLoopProxy<UserEvent>,
     exit: TrayExit,
 }
 
@@ -58,14 +61,16 @@ where
     event_loop.set_control_flow(ControlFlow::Wait);
 
     let proxy = event_loop.create_proxy();
+    let menu_proxy = proxy.clone();
     MenuEvent::set_event_handler(Some(move |event| {
-        let _ = proxy.send_event(UserEvent::Menu(event));
+        let _ = menu_proxy.send_event(UserEvent::Menu(event));
     }));
 
     let mut state = TrayState {
         app,
         tray_icon: None,
         commands: HashMap::new(),
+        event_proxy: proxy,
         exit: TrayExit::Quit,
     };
     event_loop
@@ -105,7 +110,12 @@ where
     }
 
     fn user_event(&mut self, event_loop: &ActiveEventLoop, event: UserEvent) {
-        let UserEvent::Menu(event) = event;
+        let UserEvent::Menu(event) = event else {
+            if let Err(error) = self.update_tray_menu() {
+                eprintln!("failed to refresh tray menu: {error:#}");
+            }
+            return;
+        };
         let command = self.commands.get(event.id.as_ref()).copied();
         match command {
             Some(TrayCommand::Activate(account_id)) => {
@@ -119,8 +129,20 @@ where
             Some(TrayCommand::SetAutoStartUsageWindows(enabled)) => {
                 if let Err(error) = self.app.set_auto_start_usage_windows(enabled) {
                     eprintln!("failed to update auto-start usage windows from tray: {error:#}");
-                } else if enabled && let Err(error) = self.app.auto_start_usage_windows_once(true) {
-                    eprintln!("failed to run auto-start usage window check from tray: {error:#}");
+                } else if enabled {
+                    let proxy = self.event_proxy.clone();
+                    let _ = thread::Builder::new()
+                        .name("tray-auto-start-usage-windows".to_owned())
+                        .spawn(move || {
+                            if let Err(error) =
+                                crate::app::run_auto_start_usage_windows_check_now()
+                            {
+                                eprintln!(
+                                    "failed to run auto-start usage window check from tray: {error:#}"
+                                );
+                            }
+                            let _ = proxy.send_event(UserEvent::AutoStartUsageWindowsChecked);
+                        });
                 }
                 if let Err(error) = self.update_tray_menu() {
                     eprintln!("failed to refresh tray menu: {error:#}");

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use time::OffsetDateTime;
-use tray_icon::menu::{Menu, MenuEvent, MenuId, MenuItem, PredefinedMenuItem};
+use tray_icon::menu::{CheckMenuItem, Menu, MenuEvent, MenuId, MenuItem, PredefinedMenuItem};
 use tray_icon::{Icon, TrayIcon, TrayIconBuilder};
 use uuid::Uuid;
 use winit::application::ApplicationHandler;
@@ -23,6 +23,7 @@ enum UserEvent {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum TrayCommand {
     Activate(Uuid),
+    SetAutoStartUsageWindows(bool),
     ShowTui,
     Quit,
 }
@@ -115,6 +116,16 @@ where
                     eprintln!("failed to refresh tray menu: {error:#}");
                 }
             }
+            Some(TrayCommand::SetAutoStartUsageWindows(enabled)) => {
+                if let Err(error) = self.app.set_auto_start_usage_windows(enabled) {
+                    eprintln!("failed to update auto-start usage windows from tray: {error:#}");
+                } else if enabled && let Err(error) = self.app.auto_start_usage_windows_once(true) {
+                    eprintln!("failed to run auto-start usage window check from tray: {error:#}");
+                }
+                if let Err(error) = self.update_tray_menu() {
+                    eprintln!("failed to refresh tray menu: {error:#}");
+                }
+            }
             Some(TrayCommand::ShowTui) => {
                 self.exit = TrayExit::ShowTui;
                 event_loop.exit();
@@ -175,6 +186,14 @@ where
         }
 
         menu.append(&PredefinedMenuItem::separator())?;
+        let auto_start_enabled = self.app.auto_start_usage_windows_status()?.enabled;
+        self.append_check_command(
+            &menu,
+            "toggle-auto-start-usage-windows",
+            "Auto-start usage windows",
+            auto_start_enabled,
+            TrayCommand::SetAutoStartUsageWindows(!auto_start_enabled),
+        )?;
         self.append_command(&menu, "show-tui", "Show TUI", TrayCommand::ShowTui)?;
         self.append_command(&menu, "quit", "Quit", TrayCommand::Quit)?;
         Ok(menu)
@@ -188,6 +207,25 @@ where
         command: TrayCommand,
     ) -> Result<()> {
         menu.append(&MenuItem::with_id(MenuId::new(id), label, true, None))?;
+        self.commands.insert(id.to_owned(), command);
+        Ok(())
+    }
+
+    fn append_check_command(
+        &mut self,
+        menu: &Menu,
+        id: &str,
+        label: &str,
+        checked: bool,
+        command: TrayCommand,
+    ) -> Result<()> {
+        menu.append(&CheckMenuItem::with_id(
+            MenuId::new(id),
+            label,
+            true,
+            checked,
+            None,
+        ))?;
         self.commands.insert(id.to_owned(), command);
         Ok(())
     }


### PR DESCRIPTION
## Summary
- add persisted auto-start usage-window setting with CLI, TUI, and tray toggles
- refresh saved usage every 5 minutes while interactive/tray is alive and ping due accounts via minimal codex exec
- restore the previous live account after pings and document the workflow

## Validation
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- auto-start-usage-windows --json