### PR TITLE
[codex] Mark stale accounts login required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.1.5 - 2026-05-22
+
+### Added
+
+- Added saved-account stale-login detection for expired or reused refresh tokens. Failed saved-account usage refreshes now persist a `Login required` marker so the CLI, TUI, and Windows tray can show which account needs a fresh sign-in.
+
+### Fixed
+
+- Prefer the stale-login marker over older cached weekly usage so expired accounts do not look healthy just because a previous usage snapshot still exists.
+- Refresh the Windows tray menu after background auto-start usage checks so tray rows reflect refreshed usage and login-required state without reopening the app.
+
 ## v0.1.4 - 2026-05-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codex-account-switcher"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-account-switcher"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Cross-platform CLI for saving and restoring Codex login snapshots"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ Tagged releases publish prebuilt archives plus installer scripts on GitHub Relea
 - Windows: Install prebuilt binaries via PowerShell script
 
 ```text
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/Pimpmuckl/codex-account-switcher/releases/download/v0.1.4/codex-account-switcher-installer.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/Pimpmuckl/codex-account-switcher/releases/download/v0.1.5/codex-account-switcher-installer.ps1 | iex"
 ```
 
 - macOS / Linux / WSL: Install prebuilt binaries via shell script
 
 ```text
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Pimpmuckl/codex-account-switcher/releases/download/v0.1.4/codex-account-switcher-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Pimpmuckl/codex-account-switcher/releases/download/v0.1.5/codex-account-switcher-installer.sh | sh
 ```
 
 Default installer location:
@@ -99,7 +99,7 @@ Release automation lives in:
 - `.github/workflows/ci.yml`
 - `.github/workflows/release.yml`
 
-To cut a release, bump `Cargo.toml` to the target version and push a matching tag like `v0.1.4`.
+To cut a release, bump `Cargo.toml` to the target version and push a matching tag like `v0.1.5`.
 
 ## Validation
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,6 +15,7 @@ use crate::model::{
     AccountUsageView, AccountView, DisplayIdentity, RunningCodexProcess, SavedAccountMetadata,
 };
 use crate::repository::SnapshotRepository;
+use crate::usage::usage_error_requires_login;
 
 pub struct App<S> {
     env: AppEnv,
@@ -41,6 +42,15 @@ fn account_view(
     usage: Option<AccountUsageView>,
     usage_error: Option<String>,
 ) -> AccountView {
+    let usage_error = usage_error.or(account.cached_usage_error);
+    let usage = if usage_error
+        .as_deref()
+        .is_some_and(usage_error_requires_login)
+    {
+        None
+    } else {
+        usage.or(account.cached_usage)
+    };
     AccountView {
         id: account.id,
         email: account.email,
@@ -52,7 +62,7 @@ fn account_view(
         created_at: account.created_at,
         updated_at: account.updated_at,
         last_activated_at: account.last_activated_at,
-        usage: usage.or(account.cached_usage),
+        usage,
         usage_error,
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,9 +4,11 @@ mod tui;
 
 use uuid::Uuid;
 
-#[cfg(windows)]
-pub(crate) use auto_start::run_auto_start_usage_windows_check_now;
 pub use auto_start::spawn_auto_start_usage_windows_worker;
+#[cfg(windows)]
+pub(crate) use auto_start::{
+    run_auto_start_usage_windows_check_now, subscribe_auto_start_usage_windows_checks,
+};
 
 use crate::env::AppEnv;
 use crate::model::{

--- a/src/app/auto_start.rs
+++ b/src/app/auto_start.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::Path;
 use std::process::{Command, ExitStatus, Stdio};
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration as StdDuration, Instant};
@@ -146,6 +147,18 @@ where
 }
 
 static AUTO_START_RUN_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+static AUTO_START_CHECK_LISTENERS: OnceLock<Mutex<Vec<Sender<()>>>> = OnceLock::new();
+
+#[cfg(windows)]
+pub(crate) fn subscribe_auto_start_usage_windows_checks() -> Receiver<()> {
+    let (sender, receiver) = mpsc::channel();
+    let mut listeners = AUTO_START_CHECK_LISTENERS
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .expect("auto-start usage-window listener lock poisoned");
+    listeners.push(sender);
+    receiver
+}
 
 pub fn spawn_auto_start_usage_windows_worker(env: AppEnv) {
     static STARTED: OnceLock<()> = OnceLock::new();
@@ -157,10 +170,22 @@ pub fn spawn_auto_start_usage_windows_worker(env: AppEnv) {
                     if let Err(error) = run_auto_start_usage_windows_for_env(env.clone()) {
                         eprintln!("auto-start usage-window check failed: {error:#}");
                     }
+                    notify_auto_start_usage_windows_checked();
                     thread::sleep(StdDuration::from_secs(AUTO_START_USAGE_WINDOW_POLL_SECONDS));
                 }
             });
     });
+}
+
+fn notify_auto_start_usage_windows_checked() {
+    let Some(listeners) = AUTO_START_CHECK_LISTENERS.get() else {
+        return;
+    };
+    let Ok(mut listeners) = listeners.lock() else {
+        eprintln!("auto-start usage-window listener lock poisoned");
+        return;
+    };
+    listeners.retain(|listener| listener.send(()).is_ok());
 }
 
 #[cfg(windows)]
@@ -431,6 +456,18 @@ mod tests {
         assert!(usage_window_needs_ping(now, now));
         assert!(usage_window_needs_ping(now - Duration::minutes(1), now));
         assert!(!usage_window_needs_ping(now + Duration::minutes(1), now));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn auto_start_check_notification_reaches_listener() {
+        let receiver = subscribe_auto_start_usage_windows_checks();
+
+        notify_auto_start_usage_windows_checked();
+
+        receiver
+            .recv_timeout(StdDuration::from_secs(1))
+            .expect("listener should receive auto-start check notification");
     }
 
     #[test]

--- a/src/app/auto_start.rs
+++ b/src/app/auto_start.rs
@@ -1,7 +1,9 @@
 use std::fs;
 use std::path::Path;
 use std::process::{Command, ExitStatus, Stdio};
-use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::mpsc::Sender;
+#[cfg(windows)]
+use std::sync::mpsc::{self, Receiver};
 use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration as StdDuration, Instant};

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -10,7 +10,7 @@ use crate::model::{
 };
 use crate::repository::SnapshotRepository;
 use crate::secrets::SecretStore;
-use crate::usage::{fetch_usage, usage_target_from_snapshot};
+use crate::usage::{fetch_usage, usage_error_message, usage_target_from_snapshot};
 
 use super::{
     App, account_view, match_saved_account, saved_identity, should_verify_activation_stability,
@@ -173,7 +173,17 @@ where
                     UsageSource::SavedAccessToken,
                     true,
                 )?;
-                let (output, refreshed_snapshot) = fetch_usage(target)?;
+                let (output, refreshed_snapshot) = match fetch_usage(target) {
+                    Ok(result) => result,
+                    Err(error) => {
+                        let _ = self.repository.record_usage_error(
+                            &self.env.kind,
+                            account_id,
+                            usage_error_message(&error),
+                        );
+                        return Err(error);
+                    }
+                };
                 self.repository.replace_snapshot(
                     &self.env.kind,
                     account_id,
@@ -190,6 +200,7 @@ where
                         self.env.codex_root.display()
                     )
                 })?;
+                let live_identity = live.identity.clone();
                 let live_snapshot = live.snapshot.clone();
                 let target = usage_target_from_snapshot(
                     self.env.kind.clone(),
@@ -197,16 +208,52 @@ where
                     UsageSource::LiveAccessToken,
                     true,
                 )?;
-                let (output, refreshed_snapshot) = fetch_usage(target)?;
+                let (output, refreshed_snapshot) = match fetch_usage(target) {
+                    Ok(result) => result,
+                    Err(error) => {
+                        self.record_usage_error_for_identity(&live_identity, &error);
+                        return Err(error);
+                    }
+                };
                 if refreshed_snapshot != live_snapshot
                     && live_bundle_still_matches_snapshot(&self.env, &live_snapshot)
                 {
                     codex::restore_snapshot(&self.env, &refreshed_snapshot, &output.account, false)
                         .context("refreshed live auth but failed to update local auth files")?;
                 }
+                if let Some(account_id) = self.saved_account_id_for_identity(&live_identity) {
+                    self.repository.replace_snapshot(
+                        &self.env.kind,
+                        account_id,
+                        &output.account,
+                        &refreshed_snapshot,
+                        Some(output.usage.clone()),
+                    )?;
+                }
                 Ok(output)
             }
         }
+    }
+
+    fn saved_account_id_for_identity(&self, identity: &DisplayIdentity) -> Option<Uuid> {
+        self.repository
+            .list_accounts(&self.env.kind)
+            .ok()
+            .and_then(|accounts| match_saved_account(&accounts, identity).map(|account| account.id))
+    }
+
+    fn record_usage_error_for_identity(&self, identity: &DisplayIdentity, error: &anyhow::Error) {
+        let Ok(accounts) = self.repository.list_accounts(&self.env.kind) else {
+            return;
+        };
+        let Some(account) = match_saved_account(&accounts, identity) else {
+            return;
+        };
+        let _ = self.repository.record_usage_error(
+            &self.env.kind,
+            account.id,
+            usage_error_message(error),
+        );
     }
 
     pub fn delete(&self, account_id: Uuid) -> Result<DeleteOutput> {
@@ -237,8 +284,12 @@ mod tests {
 
     use super::*;
     use crate::codex::auth_json_fixture;
+    use time::OffsetDateTime;
+
     use crate::model::SnapshotFile;
-    use crate::model::{DisplayIdentity, EnvironmentKind};
+    use crate::model::{
+        AccountUsageView, DisplayIdentity, EnvironmentKind, UsageSource, UsageWindowView,
+    };
     use crate::secrets::test_support::MemorySecretStore;
 
     #[test]
@@ -314,6 +365,134 @@ mod tests {
         assert_eq!(output.accounts.len(), 1);
         assert_eq!(output.accounts[0].email, "saved@example.com");
         assert!(!output.accounts[0].is_active);
+    }
+
+    #[test]
+    fn list_surfaces_cached_usage_error() {
+        let temp = tempdir().expect("tempdir");
+        let env = AppEnv {
+            kind: EnvironmentKind::Linux,
+            home_dir: temp.path().to_path_buf(),
+            codex_root: temp.path().join(".codex"),
+            app_data_dir: temp.path().join("app"),
+        };
+        let repo = SnapshotRepository::new(&env.app_data_dir, MemorySecretStore::default());
+        let saved = repo
+            .save_snapshot(
+                &env.kind,
+                &DisplayIdentity {
+                    email: "expired@example.com".to_owned(),
+                    subject: Some("sub-1".to_owned()),
+                    name: None,
+                    plan_label: Some("Pro".to_owned()),
+                },
+                &SnapshotBlob {
+                    schema_version: 1,
+                    files: vec![],
+                },
+            )
+            .expect("save")
+            .0;
+        repo.replace_snapshot(
+            &env.kind,
+            saved.id,
+            &DisplayIdentity {
+                email: "expired@example.com".to_owned(),
+                subject: Some("sub-1".to_owned()),
+                name: None,
+                plan_label: Some("Pro".to_owned()),
+            },
+            &SnapshotBlob {
+                schema_version: 1,
+                files: vec![],
+            },
+            Some(AccountUsageView {
+                source: UsageSource::SavedAccessToken,
+                fetched_at: OffsetDateTime::UNIX_EPOCH,
+                five_hour: None,
+                weekly: Some(UsageWindowView {
+                    used_percent: 0,
+                    remaining_percent: 100,
+                    reset_at: OffsetDateTime::UNIX_EPOCH,
+                }),
+                credits: None,
+            }),
+        )
+        .expect("replace");
+        repo.record_usage_error(
+            &env.kind,
+            saved.id,
+            "Login required: Codex auth expired or was logged out.".to_owned(),
+        )
+        .expect("record usage error");
+
+        let app = App::new(env, repo);
+        let output = app.list().expect("list");
+
+        assert_eq!(
+            output.accounts[0].usage_error.as_deref(),
+            Some("Login required: Codex auth expired or was logged out.")
+        );
+        assert!(output.accounts[0].usage.is_none());
+    }
+
+    #[test]
+    fn list_keeps_cached_usage_for_transient_usage_error() {
+        let temp = tempdir().expect("tempdir");
+        let env = AppEnv {
+            kind: EnvironmentKind::Linux,
+            home_dir: temp.path().to_path_buf(),
+            codex_root: temp.path().join(".codex"),
+            app_data_dir: temp.path().join("app"),
+        };
+        let repo = SnapshotRepository::new(&env.app_data_dir, MemorySecretStore::default());
+        let identity = DisplayIdentity {
+            email: "person@example.com".to_owned(),
+            subject: Some("sub-1".to_owned()),
+            name: None,
+            plan_label: Some("Pro".to_owned()),
+        };
+        let snapshot = SnapshotBlob {
+            schema_version: 1,
+            files: vec![],
+        };
+        let saved = repo
+            .save_snapshot(&env.kind, &identity, &snapshot)
+            .expect("save")
+            .0;
+        repo.replace_snapshot(
+            &env.kind,
+            saved.id,
+            &identity,
+            &snapshot,
+            Some(AccountUsageView {
+                source: UsageSource::SavedAccessToken,
+                fetched_at: OffsetDateTime::UNIX_EPOCH,
+                five_hour: None,
+                weekly: Some(UsageWindowView {
+                    used_percent: 10,
+                    remaining_percent: 90,
+                    reset_at: OffsetDateTime::UNIX_EPOCH,
+                }),
+                credits: None,
+            }),
+        )
+        .expect("replace");
+        repo.record_usage_error(
+            &env.kind,
+            saved.id,
+            "Usage unavailable: failed to query Codex usage".to_owned(),
+        )
+        .expect("record usage error");
+
+        let app = App::new(env, repo);
+        let output = app.list().expect("list");
+
+        assert!(output.accounts[0].usage.is_some());
+        assert_eq!(
+            output.accounts[0].usage_error.as_deref(),
+            Some("Usage unavailable: failed to query Codex usage")
+        );
     }
 
     #[test]

--- a/src/app/tui.rs
+++ b/src/app/tui.rs
@@ -10,6 +10,7 @@ use crate::model::{
 };
 use crate::process::format_process_table;
 use crate::secrets::SecretStore;
+use crate::usage::{usage_error_label, usage_error_requires_login};
 
 use super::{App, InteractiveExit, InteractiveMode, account_view_matches_identity};
 
@@ -314,7 +315,16 @@ fn render_account_label(account: &AccountView, widths: AccountLabelWidths) -> St
         width = widths.plan
     );
 
-    let (remaining, reset) = if let Some(usage) = &account.usage
+    let (remaining, reset) = if account
+        .usage_error
+        .as_deref()
+        .is_some_and(usage_error_requires_login)
+    {
+        (
+            usage_error_label(account.usage_error.as_deref().unwrap_or_default()).to_owned(),
+            String::new(),
+        )
+    } else if let Some(usage) = &account.usage
         && let Some(weekly) = &usage.weekly
     {
         if weekly.reset_at <= OffsetDateTime::now_utc() {
@@ -325,8 +335,8 @@ fn render_account_label(account: &AccountView, widths: AccountLabelWidths) -> St
                 format!("Reset: {}", format_reset_at(weekly.reset_at)),
             )
         }
-    } else if account.usage_error.is_some() {
-        ("Usage unavailable".to_owned(), String::new())
+    } else if let Some(error) = &account.usage_error {
+        (usage_error_label(error).to_owned(), String::new())
     } else {
         (String::new(), String::new())
     };
@@ -351,7 +361,16 @@ fn account_label_widths(accounts: &[&AccountView]) -> AccountLabelWidths {
                 .map(|plan| format!("Plan: {plan}").len())
                 .unwrap_or(0),
         );
-        let (remaining, reset) = if let Some(usage) = &account.usage
+        let (remaining, reset) = if account
+            .usage_error
+            .as_deref()
+            .is_some_and(usage_error_requires_login)
+        {
+            (
+                usage_error_label(account.usage_error.as_deref().unwrap_or_default()).len(),
+                0,
+            )
+        } else if let Some(usage) = &account.usage
             && let Some(weekly) = &usage.weekly
         {
             if weekly.reset_at <= OffsetDateTime::now_utc() {
@@ -362,8 +381,8 @@ fn account_label_widths(accounts: &[&AccountView]) -> AccountLabelWidths {
                     format!("Reset: {}", format_reset_at(weekly.reset_at)).len(),
                 )
             }
-        } else if account.usage_error.is_some() {
-            ("Usage unavailable".len(), 0)
+        } else if let Some(error) = &account.usage_error {
+            (usage_error_label(error).len(), 0)
         } else {
             (0, 0)
         };
@@ -938,6 +957,68 @@ mod tests {
         );
 
         assert!(label.contains("Reset: 2099-05-12 13:56"));
+    }
+
+    #[test]
+    fn account_label_marks_login_required_usage_error() {
+        let id = Uuid::new_v4();
+        let mut list = sample_list(id, false);
+        list.accounts[0].usage = Some(AccountUsageView {
+            source: UsageSource::SavedAccessToken,
+            fetched_at: OffsetDateTime::UNIX_EPOCH,
+            five_hour: None,
+            weekly: Some(UsageWindowView {
+                used_percent: 0,
+                remaining_percent: 100,
+                reset_at: OffsetDateTime::UNIX_EPOCH
+                    .replace_date(
+                        time::Date::from_calendar_date(2099, time::Month::May, 12).unwrap(),
+                    )
+                    .replace_time(time::Time::from_hms(13, 56, 0).unwrap()),
+            }),
+            credits: None,
+        });
+        list.accounts[0].usage_error = Some("Login required: Codex auth expired.".to_owned());
+
+        let label = render_account_label(
+            &list.accounts[0],
+            account_label_widths(&[&list.accounts[0]]),
+        );
+
+        assert!(label.contains("Login required"));
+        assert!(!label.contains("Usage unavailable"));
+        assert!(!label.contains("Weekly Remaining"));
+    }
+
+    #[test]
+    fn account_label_keeps_cached_usage_for_transient_usage_error() {
+        let id = Uuid::new_v4();
+        let mut list = sample_list(id, false);
+        list.accounts[0].usage = Some(AccountUsageView {
+            source: UsageSource::SavedAccessToken,
+            fetched_at: OffsetDateTime::UNIX_EPOCH,
+            five_hour: None,
+            weekly: Some(UsageWindowView {
+                used_percent: 10,
+                remaining_percent: 90,
+                reset_at: OffsetDateTime::UNIX_EPOCH
+                    .replace_date(
+                        time::Date::from_calendar_date(2099, time::Month::May, 12).unwrap(),
+                    )
+                    .replace_time(time::Time::from_hms(13, 56, 0).unwrap()),
+            }),
+            credits: None,
+        });
+        list.accounts[0].usage_error =
+            Some("Usage unavailable: failed to query Codex usage".to_owned());
+
+        let label = render_account_label(
+            &list.accounts[0],
+            account_label_widths(&[&list.accounts[0]]),
+        );
+
+        assert!(label.contains("Weekly Remaining: 90%"));
+        assert!(!label.contains("Usage unavailable"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,7 @@ use crate::model::{
 use crate::process::format_process_table;
 use crate::repository::SnapshotRepository;
 use crate::secrets::MigratingSecretStore;
+use crate::usage::{usage_error_label, usage_error_requires_login};
 
 #[derive(Parser)]
 #[command(
@@ -263,7 +264,16 @@ fn render_account_summary(account: &AccountView) -> String {
         account.email,
         if account.is_active { " [active]" } else { "" }
     );
-    if let Some(usage) = &account.usage
+    if account
+        .usage_error
+        .as_deref()
+        .is_some_and(usage_error_requires_login)
+    {
+        line.push_str(&format!(
+            " [{}]",
+            usage_error_label(account.usage_error.as_deref().unwrap_or_default()).to_lowercase()
+        ));
+    } else if let Some(usage) = &account.usage
         && let Some(weekly) = &usage.weekly
     {
         if weekly.reset_at <= OffsetDateTime::now_utc() {
@@ -275,8 +285,8 @@ fn render_account_summary(account: &AccountView) -> String {
                 weekly.reset_at.date()
             ));
         }
-    } else if account.usage_error.is_some() {
-        line.push_str(" [usage unavailable]");
+    } else if let Some(error) = &account.usage_error {
+        line.push_str(&format!(" [{}]", usage_error_label(error).to_lowercase()));
     }
     line
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -103,6 +103,8 @@ pub struct SavedAccountMetadata {
     pub last_activated_at: Option<OffsetDateTime>,
     #[serde(default)]
     pub cached_usage: Option<AccountUsageView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cached_usage_error: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -11,6 +11,7 @@ use crate::model::{
     AccountUsageView, DisplayIdentity, EnvironmentKind, SavedAccountMetadata, SnapshotBlob,
 };
 use crate::secrets::SecretStore;
+use crate::usage::usage_error_requires_login;
 use codec::{decode_snapshot, encode_snapshot};
 use index_store::MetadataIndexStore;
 
@@ -82,6 +83,7 @@ where
             account.subject = identity.subject.clone();
             account.name = identity.name.clone();
             account.plan_label = identity.plan_label.clone();
+            account.cached_usage_error = None;
             account.updated_at = now;
             (account.clone(), false)
         } else {
@@ -98,6 +100,7 @@ where
                 updated_at: now,
                 last_activated_at: None,
                 cached_usage: None,
+                cached_usage_error: None,
             };
             index.accounts.push(metadata.clone());
             (metadata, true)
@@ -151,9 +154,37 @@ where
         account.name = identity.name.clone();
         account.plan_label = identity.plan_label.clone();
         account.cached_usage = usage;
+        account.cached_usage_error = None;
         let metadata = account.clone();
         self.secret_store
             .save(&metadata.secret_key, &encoded_snapshot)?;
+        self.index_store.save_index(&index)?;
+        Ok(metadata)
+    }
+
+    pub fn record_usage_error(
+        &self,
+        environment: &EnvironmentKind,
+        account_id: Uuid,
+        usage_error: String,
+    ) -> Result<SavedAccountMetadata> {
+        let mut index = self.index_store.load_index()?;
+        let position = index
+            .accounts
+            .iter()
+            .position(|account| account.id == account_id && &account.environment == environment)
+            .ok_or_else(|| anyhow!("saved account {account_id} not found"))?;
+        let account = &mut index.accounts[position];
+        if account
+            .cached_usage_error
+            .as_deref()
+            .is_some_and(usage_error_requires_login)
+            && !usage_error_requires_login(&usage_error)
+        {
+            return Ok(account.clone());
+        }
+        account.cached_usage_error = Some(usage_error);
+        let metadata = account.clone();
         self.index_store.save_index(&index)?;
         Ok(metadata)
     }
@@ -747,6 +778,82 @@ mod tests {
         assert_eq!(loaded.files.len(), snapshot.files.len());
         assert_eq!(loaded.files[0].bytes_base64, "auth-payload");
         assert_eq!(loaded.files[1].bytes_base64, "cap-payload");
+    }
+
+    #[test]
+    fn usage_error_is_persisted_and_cleared_by_snapshot_refresh() {
+        let temp = tempdir().expect("tempdir");
+        let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
+        let env = EnvironmentKind::Windows;
+        let snapshot = SnapshotBlob {
+            schema_version: 1,
+            files: vec![],
+        };
+        let saved = repo
+            .save_snapshot(&env, &identity("person@example.com", "sub-1"), &snapshot)
+            .expect("save")
+            .0;
+
+        repo.record_usage_error(&env, saved.id, "Login required".to_owned())
+            .expect("record error");
+        assert_eq!(
+            repo.get_account(&env, saved.id)
+                .expect("get")
+                .expect("account")
+                .cached_usage_error
+                .as_deref(),
+            Some("Login required")
+        );
+
+        repo.replace_snapshot(
+            &env,
+            saved.id,
+            &identity("person@example.com", "sub-1"),
+            &snapshot,
+            None,
+        )
+        .expect("replace");
+
+        assert!(
+            repo.get_account(&env, saved.id)
+                .expect("get")
+                .expect("account")
+                .cached_usage_error
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn transient_usage_error_does_not_replace_login_required_marker() {
+        let temp = tempdir().expect("tempdir");
+        let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
+        let env = EnvironmentKind::Windows;
+        let snapshot = SnapshotBlob {
+            schema_version: 1,
+            files: vec![],
+        };
+        let saved = repo
+            .save_snapshot(&env, &identity("person@example.com", "sub-1"), &snapshot)
+            .expect("save")
+            .0;
+
+        repo.record_usage_error(&env, saved.id, "Login required".to_owned())
+            .expect("record login error");
+        repo.record_usage_error(
+            &env,
+            saved.id,
+            "Usage unavailable: failed to query Codex usage".to_owned(),
+        )
+        .expect("record transient error");
+
+        assert_eq!(
+            repo.get_account(&env, saved.id)
+                .expect("get")
+                .expect("account")
+                .cached_usage_error
+                .as_deref(),
+            Some("Login required")
+        );
     }
 
     #[test]

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -15,6 +15,7 @@ use winit::window::WindowId;
 use crate::app::App;
 use crate::model::{AccountView, DisplayIdentity};
 use crate::secrets::SecretStore;
+use crate::usage::{usage_error_label, usage_error_requires_login};
 
 #[derive(Debug)]
 enum UserEvent {
@@ -395,7 +396,16 @@ impl TrayLabelWidths {
 }
 
 fn account_usage_labels(account: &AccountView) -> (String, String) {
-    if let Some(usage) = &account.usage
+    if account
+        .usage_error
+        .as_deref()
+        .is_some_and(usage_error_requires_login)
+    {
+        (
+            usage_error_label(account.usage_error.as_deref().unwrap_or_default()).to_owned(),
+            String::new(),
+        )
+    } else if let Some(usage) = &account.usage
         && let Some(weekly) = &usage.weekly
     {
         if weekly.reset_at <= OffsetDateTime::now_utc() {
@@ -409,8 +419,8 @@ fn account_usage_labels(account: &AccountView) -> (String, String) {
                 format!("Reset: {}", format_reset_at(weekly.reset_at)),
             )
         }
-    } else if account.usage_error.is_some() {
-        ("Usage unavailable".to_owned(), String::new())
+    } else if let Some(error) = &account.usage_error {
+        (usage_error_label(error).to_owned(), String::new())
     } else {
         (String::new(), String::new())
     }
@@ -578,6 +588,42 @@ mod tests {
                 tray_detail_separator()
             )
         );
+    }
+
+    #[test]
+    fn tray_account_label_marks_login_required_usage_error() {
+        let account = AccountView {
+            id: Uuid::new_v4(),
+            email: "person@example.com".to_owned(),
+            subject: Some("sub".to_owned()),
+            name: None,
+            plan_label: Some("Pro".to_owned()),
+            environment: EnvironmentKind::Windows,
+            is_active: false,
+            created_at: OffsetDateTime::UNIX_EPOCH,
+            updated_at: OffsetDateTime::UNIX_EPOCH,
+            last_activated_at: None,
+            usage: Some(AccountUsageView {
+                source: UsageSource::SavedAccessToken,
+                fetched_at: OffsetDateTime::UNIX_EPOCH,
+                five_hour: None,
+                weekly: Some(UsageWindowView {
+                    used_percent: 0,
+                    remaining_percent: 100,
+                    reset_at: OffsetDateTime::UNIX_EPOCH
+                        .replace_date(Date::from_calendar_date(2099, Month::May, 12).unwrap())
+                        .replace_time(Time::from_hms(13, 56, 0).unwrap()),
+                }),
+                credits: None,
+            }),
+            usage_error: Some("Login required: Codex auth expired.".to_owned()),
+        };
+
+        let label = tray_account_label(&account, tray_label_widths(&[&account]));
+
+        assert!(label.contains("Login required"));
+        assert!(!label.contains("Usage unavailable"));
+        assert!(!label.contains("Weekly Remaining"));
     }
 
     #[test]

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -65,6 +65,7 @@ where
     MenuEvent::set_event_handler(Some(move |event| {
         let _ = menu_proxy.send_event(UserEvent::Menu(event));
     }));
+    spawn_auto_start_usage_windows_menu_refresh(proxy.clone());
 
     let mut state = TrayState {
         app,
@@ -77,6 +78,22 @@ where
         .run_app(&mut state)
         .context("tray event loop failed")?;
     Ok(state.exit)
+}
+
+fn spawn_auto_start_usage_windows_menu_refresh(proxy: EventLoopProxy<UserEvent>) {
+    let receiver = crate::app::subscribe_auto_start_usage_windows_checks();
+    let _ = thread::Builder::new()
+        .name("tray-auto-start-usage-windows-menu-refresh".to_owned())
+        .spawn(move || {
+            while receiver.recv().is_ok() {
+                if proxy
+                    .send_event(UserEvent::AutoStartUsageWindowsChecked)
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
 }
 
 impl<S> ApplicationHandler<UserEvent> for TrayState<'_, S>

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -58,6 +58,36 @@ pub fn fetch_usage(target: UsageTarget) -> Result<(UsageOutput, SnapshotBlob)> {
     ))
 }
 
+pub fn usage_error_message(error: &anyhow::Error) -> String {
+    let rendered = format!("{error:#}");
+    if usage_error_requires_login(&rendered) {
+        "Login required: Codex auth expired or was logged out. Log in with this account again, then refresh/save it.".to_owned()
+    } else {
+        let detail = rendered.lines().next().unwrap_or("unknown error");
+        format!("Usage unavailable: {detail}")
+    }
+}
+
+pub fn usage_error_label(error: &str) -> &'static str {
+    if usage_error_requires_login(error) {
+        "Login required"
+    } else {
+        "Usage unavailable"
+    }
+}
+
+pub fn usage_error_requires_login(error: &str) -> bool {
+    let error = error.to_ascii_lowercase();
+    error.contains("login required")
+        || error.contains("usage authorization failed")
+        || error.contains("snapshot refresh token missing")
+        || (error.contains("token refresh failed")
+            && (error.contains("invalid_grant")
+                || error.contains("refresh token")
+                || error.contains("log out")
+                || error.contains("sign in")))
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct StoredAuth {
     tokens: StoredTokens,
@@ -371,4 +401,30 @@ pub fn usage_target_from_snapshot(
         source,
         allow_refresh,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::anyhow;
+
+    use super::*;
+
+    #[test]
+    fn reused_refresh_token_error_is_login_required() {
+        let error = anyhow!(
+            "token refresh failed with 400 Bad Request: {{\"error\":\"invalid_grant\",\"error_description\":\"Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.\"}}"
+        );
+        let message = usage_error_message(&error);
+
+        assert_eq!(usage_error_label(&message), "Login required");
+        assert!(message.contains("Log in with this account again"));
+    }
+
+    #[test]
+    fn non_auth_usage_error_stays_usage_unavailable() {
+        let message = usage_error_message(&anyhow!("failed to query Codex usage"));
+
+        assert_eq!(usage_error_label(&message), "Usage unavailable");
+        assert_eq!(message, "Usage unavailable: failed to query Codex usage");
+    }
 }


### PR DESCRIPTION
## Summary
- persist usage refresh failures on saved accounts and classify expired/reused refresh tokens as `Login required`
- keep stale login markers ahead of cached usage, while preserving cached usage for transient usage errors
- refresh saved metadata after successful live usage checks and prepare `v0.1.5`

## Validation
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `cargo build --target-dir target\verify-login-required`
- `git diff --check`
- brief Review Suite `rvw_2074c10c` green after follow-up fixes

## Release
- Bumps crate/docs/changelog to `0.1.5` for the patch release tag.