### PR TITLE
fix(settings): recover interrupted writes

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,10 +1,11 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use serde::{Deserialize, Serialize};
 
-use crate::file_store::replace_file_with_recovery;
+use crate::file_store::{RecoveryFileKind, list_recovery_files, replace_file_with_recovery};
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AppSettings {
@@ -14,11 +15,66 @@ pub struct AppSettings {
 
 pub fn load_settings(app_data_dir: &Path) -> Result<AppSettings> {
     let path = settings_path(app_data_dir);
+    let mut saw_invalid = false;
+    let mut canonical_error = None;
     match fs::read(&path) {
-        Ok(bytes) => Ok(serde_json::from_slice(&bytes).unwrap_or_default()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(AppSettings::default()),
-        Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
+        Ok(bytes) => match serde_json::from_slice(&bytes) {
+            Ok(settings) => return Ok(settings),
+            Err(_) => saw_invalid = true,
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            canonical_error =
+                Some(Err(error).with_context(|| format!("failed to read {}", path.display())));
+        }
     }
+
+    let pending_path = pending_settings_path(&path);
+    let entries = list_recovery_files(&path, Some(&pending_path))?;
+    if entries.is_empty() && canonical_error.is_none() && !saw_invalid {
+        return Ok(AppSettings::default());
+    }
+
+    let mut recovery_candidates = Vec::new();
+    for entry in entries {
+        if entry.kind == RecoveryFileKind::Canonical {
+            continue;
+        }
+        let bytes = match fs::read(&entry.path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(_) => continue,
+        };
+        let settings = match serde_json::from_slice::<AppSettings>(&bytes) {
+            Ok(settings) => settings,
+            Err(_) => {
+                saw_invalid = true;
+                continue;
+            }
+        };
+        recovery_candidates.push(SettingsRecoveryCandidate {
+            modified: entry.modified,
+            settings,
+        });
+    }
+
+    if let Some(candidate) = recovery_candidates
+        .into_iter()
+        .max_by_key(|candidate| candidate.modified)
+    {
+        save_settings(app_data_dir, &candidate.settings)?;
+        return Ok(candidate.settings);
+    }
+
+    if saw_invalid {
+        return Err(settings_recovery_error(&path));
+    }
+
+    if let Some(error) = canonical_error {
+        return error;
+    }
+
+    Ok(AppSettings::default())
 }
 
 pub fn save_settings(app_data_dir: &Path, settings: &AppSettings) -> Result<()> {
@@ -35,6 +91,29 @@ pub fn save_settings(app_data_dir: &Path, settings: &AppSettings) -> Result<()> 
 
 fn settings_path(app_data_dir: &Path) -> PathBuf {
     app_data_dir.join("settings.json")
+}
+
+fn pending_settings_path(path: &Path) -> PathBuf {
+    path.with_extension(format!(
+        "{}.pending",
+        path.extension()
+            .and_then(|value| value.to_str())
+            .unwrap_or_default()
+    ))
+}
+
+fn settings_recovery_error(path: &Path) -> anyhow::Error {
+    anyhow!(
+        "settings recovery failed for {}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("settings.json")
+    )
+}
+
+struct SettingsRecoveryCandidate {
+    modified: SystemTime,
+    settings: AppSettings,
 }
 
 #[cfg(test)]
@@ -69,13 +148,110 @@ mod tests {
     }
 
     #[test]
-    fn malformed_settings_default_to_disabled() {
+    fn valid_settings_ignore_stale_unreadable_recovery_artifact() {
         let temp = tempdir().expect("tempdir");
-        std::fs::create_dir_all(temp.path()).expect("settings dir");
-        std::fs::write(settings_path(temp.path()), "{").expect("settings file");
+        save_settings(
+            temp.path(),
+            &AppSettings {
+                auto_start_usage_windows: true,
+            },
+        )
+        .expect("save settings");
+        std::fs::create_dir(temp.path().join("settings.json.bak-stale"))
+            .expect("stale backup directory");
+
+        let settings = load_settings(temp.path()).expect("load settings");
+
+        assert!(settings.auto_start_usage_windows);
+    }
+
+    #[test]
+    fn missing_settings_ignore_stale_unreadable_recovery_artifact() {
+        let temp = tempdir().expect("tempdir");
+        std::fs::create_dir(temp.path().join("settings.json.bak-stale"))
+            .expect("stale backup directory");
 
         let settings = load_settings(temp.path()).expect("load settings");
 
         assert!(!settings.auto_start_usage_windows);
+    }
+
+    #[test]
+    fn malformed_settings_with_valid_backup_recovers_enabled() {
+        let temp = tempdir().expect("tempdir");
+        std::fs::create_dir_all(temp.path()).expect("settings dir");
+        std::fs::write(settings_path(temp.path()), "{").expect("settings file");
+        write_settings(
+            &temp.path().join("settings.json.bak-test"),
+            &AppSettings {
+                auto_start_usage_windows: true,
+            },
+        );
+
+        let settings = load_settings(temp.path()).expect("load settings");
+
+        assert!(settings.auto_start_usage_windows);
+        assert_eq!(
+            serde_json::from_slice::<AppSettings>(
+                &std::fs::read(settings_path(temp.path())).expect("canonical settings")
+            )
+            .expect("parse canonical settings"),
+            settings
+        );
+    }
+
+    #[test]
+    fn unreadable_canonical_with_valid_backup_recovers_enabled() {
+        let temp = tempdir().expect("tempdir");
+        std::fs::create_dir(temp.path().join("settings.json")).expect("settings directory");
+        write_settings(
+            &temp.path().join("settings.json.bak-test"),
+            &AppSettings {
+                auto_start_usage_windows: true,
+            },
+        );
+
+        let settings = load_settings(temp.path()).expect("load settings");
+
+        assert!(settings.auto_start_usage_windows);
+    }
+
+    #[test]
+    fn malformed_settings_with_valid_pending_recovers_enabled() {
+        let temp = tempdir().expect("tempdir");
+        std::fs::create_dir_all(temp.path()).expect("settings dir");
+        let path = settings_path(temp.path());
+        std::fs::write(&path, "{").expect("settings file");
+        write_settings(
+            &pending_settings_path(&path),
+            &AppSettings {
+                auto_start_usage_windows: true,
+            },
+        );
+
+        let settings = load_settings(temp.path()).expect("load settings");
+
+        assert!(settings.auto_start_usage_windows);
+    }
+
+    #[test]
+    fn malformed_settings_returns_error_without_recovery_candidate() {
+        let temp = tempdir().expect("tempdir");
+        std::fs::create_dir_all(temp.path()).expect("settings dir");
+        std::fs::write(settings_path(temp.path()), "{").expect("settings file");
+
+        let error = load_settings(temp.path()).expect_err("invalid settings should fail");
+
+        let rendered = format!("{error:#}");
+        assert!(rendered.contains("settings.json"));
+        assert!(rendered.contains("settings recovery failed"));
+    }
+
+    fn write_settings(path: &Path, settings: &AppSettings) {
+        std::fs::write(
+            path,
+            serde_json::to_vec_pretty(settings).expect("encode settings"),
+        )
+        .expect("write settings");
     }
 }


### PR DESCRIPTION
## Summary
- Recover settings from valid backup, pending, or temp recovery artifacts when canonical settings are missing, malformed, or unreadable.
- Preserve missing-settings default behavior and make invalid-only settings recovery state fail loudly instead of silently disabling auto-start usage windows.
- Add settings tests for missing/default, round trip, backup recovery, pending recovery, invalid-only error, and unreadable stale artifact handling.

## Validation
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- Review Suite brief: rvw_7b8f09b5

## Review Notes
- Fixed valid Review Suite findings around stale unreadable artifacts and canonical read errors.
- Overrode the repeated pending-over-valid-canonical finding because Plan 004 explicitly requires valid canonical settings to be preferred before non-canonical recovery candidates.