### PR TITLE
[codex] Simplify saved account snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,12 +176,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,7 +312,6 @@ dependencies = [
  "directories",
  "flate2",
  "image",
- "keyring",
  "serde",
  "serde_json",
  "sysinfo",
@@ -409,16 +402,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,9 +414,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -444,7 +427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
+ "core-foundation",
  "libc",
 ]
 
@@ -477,28 +460,6 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
-
-[[package]]
-name = "dbus"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
-dependencies = [
- "libc",
- "libdbus-sys",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "dbus-secret-service"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
-dependencies = [
- "dbus",
- "openssl",
- "zeroize",
-]
 
 [[package]]
 name = "deranged"
@@ -674,21 +635,12 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -701,12 +653,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1308,22 +1254,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
-dependencies = [
- "byteorder",
- "dbus-secret-service",
- "log",
- "openssl",
- "security-framework 2.11.1",
- "security-framework 3.7.0",
- "windows-sys 0.60.2",
- "zeroize",
-]
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,16 +1288,6 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
-
-[[package]]
-name = "libdbus-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[package]]
 name = "libloading"
@@ -1850,54 +1770,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "openssl-src"
-version = "300.6.0+3.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2262,42 +2134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2839,12 +2675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3327,7 +3157,7 @@ dependencies = [
  "calloop",
  "cfg_aliases",
  "concurrent-queue",
- "core-foundation 0.9.4",
+ "core-foundation",
  "core-graphics",
  "cursor-icon",
  "dpi",
@@ -3543,20 +3373,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,19 +27,12 @@ uuid = { version = "1.23.0", features = ["serde", "v4"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 image = { version = "0.25.10", default-features = false, features = ["png", "ico"] }
-keyring = { version = "3.6.3", features = ["windows-native"] }
 tray-icon = { version = "0.22.1", default-features = false }
 windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_System_Console", "Win32_UI_WindowsAndMessaging"] }
 winit = { version = "0.30.13", default-features = false }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winresource = "0.1.31"
-
-[target.'cfg(target_os = "macos")'.dependencies]
-keyring = { version = "3.6.3", features = ["apple-native"] }
-
-[target.'cfg(target_os = "linux")'.dependencies]
-keyring = { version = "3.6.3", features = ["sync-secret-service", "vendored"] }
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/README.md
+++ b/README.md
@@ -49,11 +49,10 @@ Saved snapshot data lives in the app-data directory for the current environment:
 - macOS: `~/Library/Application Support/nextide/codex-account-switcher`
 - Linux / WSL: `${XDG_DATA_HOME:-~/.local/share}/nextide/codex-account-switcher`
 
-Older keyring-backed snapshots are migrated into the local store on first use when they are still readable. Metadata rows created by the broken mock-backed builds still need to be re-saved once.
-
 Account labels come from the `id_token` payload:
 
 - email
+- account identity
 - optional name
 - best-effort plan label
 
@@ -112,7 +111,7 @@ cargo fmt --check
 ## Current Limits
 
 - v1 supports only the existing live-login capture flow. It does not drive Codex login itself.
-- Saved snapshots are keyed by the current environment and current account identity.
+- Saved snapshots are keyed by the current account identity in the current app-data directory.
 - Plan metadata is best effort and may be blank if the token does not expose a recognizable value.
 - Usage enrichment depends on saved `auth.json` tokens still being present and accepted by the Codex/OpenAI usage endpoints.
 - Auto-starting usage windows can ping while Codex processes are running; active Codex sessions keep their auth cached, and the switcher restores the previous live account afterward.

--- a/src/app.rs
+++ b/src/app.rs
@@ -53,11 +53,10 @@ fn account_view(
     };
     AccountView {
         id: account.id,
+        account_key: account.account_key,
         email: account.email,
-        subject: account.subject,
         name: account.name,
         plan_label: account.plan_label,
-        environment: account.environment,
         is_active: active_id.is_some_and(|id| id == account.id),
         created_at: account.created_at,
         updated_at: account.updated_at,
@@ -78,8 +77,8 @@ fn match_saved_account<'a>(
 
 fn account_view_matches_identity(account: &AccountView, identity: &DisplayIdentity) -> bool {
     DisplayIdentity {
+        account_key: account.account_key.clone(),
         email: account.email.clone(),
-        subject: account.subject.clone(),
         name: account.name.clone(),
         plan_label: account.plan_label.clone(),
     }
@@ -88,17 +87,10 @@ fn account_view_matches_identity(account: &AccountView, identity: &DisplayIdenti
 
 fn saved_identity(account: &SavedAccountMetadata) -> DisplayIdentity {
     DisplayIdentity {
+        account_key: account.account_key.clone(),
         email: account.email.clone(),
-        subject: account.subject.clone(),
         name: account.name.clone(),
         plan_label: account.plan_label.clone(),
-    }
-}
-
-fn subject_bound_identity_matches(expected: &DisplayIdentity, snapshot: &DisplayIdentity) -> bool {
-    match (&expected.subject, &snapshot.subject) {
-        (Some(left), Some(right)) => left == right,
-        _ => false,
     }
 }
 

--- a/src/app/auto_start.rs
+++ b/src/app/auto_start.rs
@@ -19,7 +19,7 @@ use crate::model::{
     AutoStartUsageWindowsStatusOutput, DisplayIdentity, SnapshotBlob,
 };
 use crate::repository::SnapshotRepository;
-use crate::secrets::{MigratingSecretStore, SecretStore};
+use crate::secrets::{LocalSecretStore, SecretStore};
 use crate::settings::{load_settings, save_settings};
 
 use super::App;
@@ -68,7 +68,7 @@ where
             .get_or_init(|| Mutex::new(()))
             .lock()
             .map_err(|_| anyhow!("auto-start usage-window run lock poisoned"))?;
-        let accounts = self.repository.list_accounts(&self.env.kind)?;
+        let accounts = self.repository.list_accounts()?;
         output.checked_accounts = accounts.len();
         let now = OffsetDateTime::now_utc();
         let mut due_accounts = Vec::new();
@@ -114,11 +114,10 @@ where
         account_id: Uuid,
         email: &str,
     ) -> Result<AutoStartUsageWindowAccountResult> {
-        let (_, snapshot) = self.repository.load_snapshot(&self.env.kind, account_id)?;
+        let (_, snapshot) = self.repository.load_snapshot(account_id)?;
         let identity = codex::identity_from_snapshot(&snapshot)?;
         let ping_result = run_codex_usage_ping(&self.env, &snapshot, &identity)?;
-        let (current_metadata, current_snapshot) =
-            self.repository.load_snapshot(&self.env.kind, account_id)?;
+        let (current_metadata, current_snapshot) = self.repository.load_snapshot(account_id)?;
         if current_snapshot != snapshot {
             return Err(anyhow!(
                 "saved snapshot changed while ping was running; skipped write-back"
@@ -126,7 +125,6 @@ where
         }
         let refreshed_identity = codex::identity_from_snapshot(&ping_result.snapshot)?;
         self.repository.replace_snapshot(
-            &self.env.kind,
             account_id,
             &refreshed_identity,
             &ping_result.snapshot,
@@ -198,7 +196,7 @@ pub(crate) fn run_auto_start_usage_windows_check_now(env: AppEnv) -> Result<()> 
 fn run_auto_start_usage_windows_for_env(env: AppEnv) -> Result<()> {
     let repository = SnapshotRepository::new(
         &env.app_data_dir,
-        MigratingSecretStore::new(&env.app_data_dir.join("snapshots")),
+        LocalSecretStore::new(&env.app_data_dir.join("snapshots")),
     );
     let app = App::new(env, repository);
     let _ = app.auto_start_usage_windows_once(true)?;

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -14,7 +14,6 @@ use crate::usage::{fetch_usage, usage_error_message, usage_target_from_snapshot}
 
 use super::{
     App, account_view, match_saved_account, saved_identity, should_verify_activation_stability,
-    subject_bound_identity_matches,
 };
 
 impl<S> App<S>
@@ -30,7 +29,7 @@ where
     }
 
     pub fn status(&self) -> Result<StatusOutput> {
-        let saved_accounts = self.repository.list_accounts(&self.env.kind)?;
+        let saved_accounts = self.repository.list_accounts()?;
         let live = codex::try_read_live_auth_bundle(&self.env)?;
         let current_saved_id = live
             .as_ref()
@@ -47,7 +46,7 @@ where
     }
 
     pub fn list(&self) -> Result<ListOutput> {
-        let accounts = self.repository.list_accounts(&self.env.kind)?;
+        let accounts = self.repository.list_accounts()?;
         let live = codex::try_read_live_auth_bundle(&self.env)?;
         let active_id = live
             .as_ref()
@@ -69,9 +68,9 @@ where
                 self.env.codex_root.display()
             )
         })?;
-        let (metadata, created) =
-            self.repository
-                .save_snapshot(&self.env.kind, &live.identity, &live.snapshot)?;
+        let (metadata, created) = self
+            .repository
+            .save_snapshot(&live.identity, &live.snapshot)?;
         Ok(SaveOutput {
             account: account_view(metadata.clone(), Some(metadata.id), None, None),
             action: if created {
@@ -105,7 +104,7 @@ where
             .context("failed to restore the selected account snapshot")?;
         let metadata = self
             .repository
-            .sync_activated_account(&self.env.kind, account_id, &snapshot_identity)
+            .sync_activated_account(account_id, &snapshot_identity)
             .context("activated live auth but failed to update local metadata")?;
         Ok(ActivateOutput {
             account: account_view(metadata, Some(account_id), None, None),
@@ -114,7 +113,7 @@ where
     }
 
     fn refresh_current_saved_account_before_activation(&self) {
-        let Ok(saved_accounts) = self.repository.list_accounts(&self.env.kind) else {
+        let Ok(saved_accounts) = self.repository.list_accounts() else {
             return;
         };
         let Ok(Some(live)) = codex::try_read_live_auth_bundle(&self.env) else {
@@ -133,21 +132,17 @@ where
         &self,
         account_id: Uuid,
     ) -> Result<(SnapshotBlob, DisplayIdentity, DisplayIdentity)> {
-        let (metadata, snapshot) = self.repository.load_snapshot(&self.env.kind, account_id)?;
+        let (metadata, snapshot) = self.repository.load_snapshot(account_id)?;
         let expected_identity = saved_identity(&metadata);
         let snapshot_identity = codex::identity_from_snapshot(&snapshot)?;
-        let restore_identity = if expected_identity.subject.is_some() {
-            if !subject_bound_identity_matches(&expected_identity, &snapshot_identity) {
-                anyhow::bail!(
-                    "saved snapshot identity does not match the selected account: expected {:?}, got {:?}",
-                    expected_identity,
-                    snapshot_identity
-                );
-            }
-            expected_identity.clone()
-        } else {
-            snapshot_identity.clone()
-        };
+        if !expected_identity.matches(&snapshot_identity) {
+            anyhow::bail!(
+                "saved snapshot identity does not match the selected account: expected {:?}, got {:?}",
+                expected_identity,
+                snapshot_identity
+            );
+        }
+        let restore_identity = expected_identity.clone();
         Ok((snapshot, snapshot_identity, restore_identity))
     }
 
@@ -156,7 +151,7 @@ where
     }
 
     pub fn refresh_saved_usage_cache(&self) -> Result<()> {
-        let accounts = self.repository.list_accounts(&self.env.kind)?;
+        let accounts = self.repository.list_accounts()?;
         for account in accounts {
             let _ = self.usage(Some(account.id));
         }
@@ -176,16 +171,13 @@ where
                 let (output, refreshed_snapshot) = match fetch_usage(target) {
                     Ok(result) => result,
                     Err(error) => {
-                        let _ = self.repository.record_usage_error(
-                            &self.env.kind,
-                            account_id,
-                            usage_error_message(&error),
-                        );
+                        let _ = self
+                            .repository
+                            .record_usage_error(account_id, usage_error_message(&error));
                         return Err(error);
                     }
                 };
                 self.repository.replace_snapshot(
-                    &self.env.kind,
                     account_id,
                     &output.account,
                     &refreshed_snapshot,
@@ -223,7 +215,6 @@ where
                 }
                 if let Some(account_id) = self.saved_account_id_for_identity(&live_identity) {
                     self.repository.replace_snapshot(
-                        &self.env.kind,
                         account_id,
                         &output.account,
                         &refreshed_snapshot,
@@ -237,28 +228,25 @@ where
 
     fn saved_account_id_for_identity(&self, identity: &DisplayIdentity) -> Option<Uuid> {
         self.repository
-            .list_accounts(&self.env.kind)
+            .list_accounts()
             .ok()
             .and_then(|accounts| match_saved_account(&accounts, identity).map(|account| account.id))
     }
 
     fn record_usage_error_for_identity(&self, identity: &DisplayIdentity, error: &anyhow::Error) {
-        let Ok(accounts) = self.repository.list_accounts(&self.env.kind) else {
+        let Ok(accounts) = self.repository.list_accounts() else {
             return;
         };
         let Some(account) = match_saved_account(&accounts, identity) else {
             return;
         };
-        let _ = self.repository.record_usage_error(
-            &self.env.kind,
-            account.id,
-            usage_error_message(error),
-        );
+        let _ = self
+            .repository
+            .record_usage_error(account.id, usage_error_message(error));
     }
 
     pub fn delete(&self, account_id: Uuid) -> Result<DeleteOutput> {
-        self.repository
-            .delete_snapshot(&self.env.kind, account_id)?;
+        self.repository.delete_snapshot(account_id)?;
         Ok(DeleteOutput {
             deleted_account_id: account_id,
         })
@@ -310,10 +298,9 @@ mod tests {
         std::fs::write(env.codex_root.join("cap_sid"), "sid").expect("cap");
         let repo = SnapshotRepository::new(&env.app_data_dir, MemorySecretStore::default());
         repo.save_snapshot(
-            &env.kind,
             &DisplayIdentity {
                 email: "active@example.com".to_owned(),
-                subject: Some("sub-1".to_owned()),
+                account_key: "sub-1".to_owned(),
                 name: None,
                 plan_label: Some("Pro".to_owned()),
             },
@@ -347,10 +334,9 @@ mod tests {
         std::fs::write(env.codex_root.join("cap_sid"), "sid-current").expect("cap");
         let repo = SnapshotRepository::new(&env.app_data_dir, MemorySecretStore::default());
         repo.save_snapshot(
-            &env.kind,
             &DisplayIdentity {
                 email: "saved@example.com".to_owned(),
-                subject: Some("sub-1".to_owned()),
+                account_key: "sub-1".to_owned(),
                 name: None,
                 plan_label: Some("Pro".to_owned()),
             },
@@ -379,10 +365,9 @@ mod tests {
         let repo = SnapshotRepository::new(&env.app_data_dir, MemorySecretStore::default());
         let saved = repo
             .save_snapshot(
-                &env.kind,
                 &DisplayIdentity {
                     email: "expired@example.com".to_owned(),
-                    subject: Some("sub-1".to_owned()),
+                    account_key: "sub-1".to_owned(),
                     name: None,
                     plan_label: Some("Pro".to_owned()),
                 },
@@ -394,11 +379,10 @@ mod tests {
             .expect("save")
             .0;
         repo.replace_snapshot(
-            &env.kind,
             saved.id,
             &DisplayIdentity {
                 email: "expired@example.com".to_owned(),
-                subject: Some("sub-1".to_owned()),
+                account_key: "sub-1".to_owned(),
                 name: None,
                 plan_label: Some("Pro".to_owned()),
             },
@@ -420,7 +404,6 @@ mod tests {
         )
         .expect("replace");
         repo.record_usage_error(
-            &env.kind,
             saved.id,
             "Login required: Codex auth expired or was logged out.".to_owned(),
         )
@@ -448,7 +431,7 @@ mod tests {
         let repo = SnapshotRepository::new(&env.app_data_dir, MemorySecretStore::default());
         let identity = DisplayIdentity {
             email: "person@example.com".to_owned(),
-            subject: Some("sub-1".to_owned()),
+            account_key: "sub-1".to_owned(),
             name: None,
             plan_label: Some("Pro".to_owned()),
         };
@@ -456,12 +439,8 @@ mod tests {
             schema_version: 1,
             files: vec![],
         };
-        let saved = repo
-            .save_snapshot(&env.kind, &identity, &snapshot)
-            .expect("save")
-            .0;
+        let saved = repo.save_snapshot(&identity, &snapshot).expect("save").0;
         repo.replace_snapshot(
-            &env.kind,
             saved.id,
             &identity,
             &snapshot,
@@ -479,7 +458,6 @@ mod tests {
         )
         .expect("replace");
         repo.record_usage_error(
-            &env.kind,
             saved.id,
             "Usage unavailable: failed to query Codex usage".to_owned(),
         )
@@ -496,38 +474,7 @@ mod tests {
     }
 
     #[test]
-    fn subject_bound_identity_requires_matching_subject() {
-        let expected = DisplayIdentity {
-            email: "person@example.com".to_owned(),
-            subject: Some("sub-1".to_owned()),
-            name: Some("Tester".to_owned()),
-            plan_label: Some("Pro".to_owned()),
-        };
-        let missing_subject = DisplayIdentity {
-            email: "person@example.com".to_owned(),
-            subject: None,
-            name: Some("Tester".to_owned()),
-            plan_label: Some("Pro".to_owned()),
-        };
-        let wrong_subject = DisplayIdentity {
-            email: "person@example.com".to_owned(),
-            subject: Some("sub-2".to_owned()),
-            name: Some("Tester".to_owned()),
-            plan_label: Some("Pro".to_owned()),
-        };
-        let matching_subject = DisplayIdentity {
-            email: "other@example.com".to_owned(),
-            subject: Some("sub-1".to_owned()),
-            name: Some("Tester".to_owned()),
-            plan_label: Some("Pro".to_owned()),
-        };
-        assert!(!subject_bound_identity_matches(&expected, &missing_subject));
-        assert!(!subject_bound_identity_matches(&expected, &wrong_subject));
-        assert!(subject_bound_identity_matches(&expected, &matching_subject));
-    }
-
-    #[test]
-    fn activate_returns_refreshed_identity_after_subject_stable_restore() {
+    fn activate_returns_refreshed_identity_after_account_key_stable_restore() {
         let temp = tempdir().expect("tempdir");
         let env = AppEnv {
             kind: EnvironmentKind::Linux,
@@ -546,10 +493,9 @@ mod tests {
         let repo = SnapshotRepository::new(&env.app_data_dir, MemorySecretStore::default());
         let saved = repo
             .save_snapshot(
-                &env.kind,
                 &DisplayIdentity {
                     email: "before@example.com".to_owned(),
-                    subject: Some("sub-1".to_owned()),
+                    account_key: "sub-1".to_owned(),
                     name: Some("Before".to_owned()),
                     plan_label: Some("Pro".to_owned()),
                 },
@@ -601,10 +547,9 @@ mod tests {
         let repo = SnapshotRepository::new(&env.app_data_dir, MemorySecretStore::default());
         let saved = repo
             .save_snapshot(
-                &env.kind,
                 &DisplayIdentity {
                     email: "expected@example.com".to_owned(),
-                    subject: Some("sub-expected".to_owned()),
+                    account_key: "sub-expected".to_owned(),
                     name: Some("Expected".to_owned()),
                     plan_label: Some("Pro".to_owned()),
                 },
@@ -632,57 +577,5 @@ mod tests {
         assert!(format!("{error:#}").contains("does not match the selected account"));
         let live = crate::codex::read_live_auth_bundle(&env).expect("live bundle");
         assert_eq!(live.identity.email, "active@example.com");
-    }
-
-    #[test]
-    fn activate_allows_legacy_metadata_without_subject_to_refresh_email() {
-        let temp = tempdir().expect("tempdir");
-        let env = AppEnv {
-            kind: EnvironmentKind::Linux,
-            home_dir: temp.path().to_path_buf(),
-            codex_root: temp.path().join(".codex"),
-            app_data_dir: temp.path().join("app"),
-        };
-        std::fs::create_dir_all(&env.codex_root).expect("codex root");
-        std::fs::write(
-            env.codex_root.join("auth.json"),
-            auth_json_fixture("active@example.com", "sub-1", Some("pro")),
-        )
-        .expect("auth");
-        std::fs::write(env.codex_root.join("cap_sid"), "sid-a").expect("cap");
-
-        let repo = SnapshotRepository::new(&env.app_data_dir, MemorySecretStore::default());
-        let saved = repo
-            .save_snapshot(
-                &env.kind,
-                &DisplayIdentity {
-                    email: "old@example.com".to_owned(),
-                    subject: None,
-                    name: Some("Old".to_owned()),
-                    plan_label: Some("Pro".to_owned()),
-                },
-                &SnapshotBlob {
-                    schema_version: 1,
-                    files: vec![
-                        SnapshotFile {
-                            name: "auth.json".to_owned(),
-                            bytes_base64: base64::engine::general_purpose::STANDARD.encode(
-                                auth_json_fixture("new@example.com", "sub-new", Some("plus")),
-                            ),
-                        },
-                        SnapshotFile {
-                            name: "cap_sid".to_owned(),
-                            bytes_base64: base64::engine::general_purpose::STANDARD.encode("sid-b"),
-                        },
-                    ],
-                },
-            )
-            .expect("save")
-            .0;
-
-        let app = App::new(env.clone(), repo);
-        let output = app.activate(saved.id).expect("activate");
-        assert_eq!(output.account.email, "new@example.com");
-        assert_eq!(output.account.subject.as_deref(), Some("sub-new"));
     }
 }

--- a/src/app/tui.rs
+++ b/src/app/tui.rs
@@ -889,7 +889,7 @@ mod tests {
             codex_root: "C:\\Users\\tester\\.codex".to_owned(),
             current_account: current_saved_id.map(|_| DisplayIdentity {
                 email: email.to_owned(),
-                subject: Some("sub-1".to_owned()),
+                account_key: "sub-1".to_owned(),
                 name: Some("Tester".to_owned()),
                 plan_label: Some("Pro".to_owned()),
             }),
@@ -909,10 +909,9 @@ mod tests {
             accounts: vec![AccountView {
                 id,
                 email: "person@example.com".to_owned(),
-                subject: Some("sub-1".to_owned()),
+                account_key: "sub-1".to_owned(),
                 name: Some("Tester".to_owned()),
                 plan_label: Some("Pro".to_owned()),
-                environment: EnvironmentKind::Windows,
                 is_active,
                 created_at: OffsetDateTime::UNIX_EPOCH,
                 updated_at: OffsetDateTime::UNIX_EPOCH,
@@ -1163,7 +1162,7 @@ mod tests {
             codex_root: "C:\\Users\\tester\\.codex".to_owned(),
             current_account: Some(DisplayIdentity {
                 email: "other@example.com".to_owned(),
-                subject: Some("sub-2".to_owned()),
+                account_key: "sub-2".to_owned(),
                 name: Some("Other".to_owned()),
                 plan_label: Some("Plus".to_owned()),
             }),
@@ -1210,10 +1209,9 @@ mod tests {
         std::fs::write(env.codex_root.join("cap_sid"), "sid-current").expect("cap");
         let repo = SnapshotRepository::new(&env.app_data_dir, MemorySecretStore::default());
         repo.save_snapshot(
-            &env.kind,
             &DisplayIdentity {
                 email: "saved@example.com".to_owned(),
-                subject: Some("sub-1".to_owned()),
+                account_key: "sub-1".to_owned(),
                 name: None,
                 plan_label: Some("Pro".to_owned()),
             },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,7 @@ use crate::model::{
 };
 use crate::process::format_process_table;
 use crate::repository::SnapshotRepository;
-use crate::secrets::MigratingSecretStore;
+use crate::secrets::LocalSecretStore;
 use crate::usage::{usage_error_label, usage_error_requires_login};
 
 #[derive(Parser)]
@@ -73,7 +73,7 @@ pub fn run() -> Result<()> {
     let env = env::detect()?;
     let repository = SnapshotRepository::new(
         &env.app_data_dir,
-        MigratingSecretStore::new(&env.app_data_dir.join("snapshots")),
+        LocalSecretStore::new(&env.app_data_dir.join("snapshots")),
     );
     let app = App::new(env, repository);
     match cli.command {

--- a/src/codex.rs
+++ b/src/codex.rs
@@ -1130,12 +1130,14 @@ fn snapshot_files<'a>(snapshot: &'a SnapshotBlob, file_name: &str) -> Vec<&'a st
 }
 
 #[cfg(test)]
-pub fn auth_json_fixture(email: &str, subject: &str, plan: Option<&str>) -> String {
+pub fn auth_json_fixture(email: &str, account_key: &str, plan: Option<&str>) -> String {
     let payload = serde_json::json!({
         "email": email,
-        "sub": subject,
+        "sub": account_key,
         "name": "Tester",
         "https://api.openai.com/auth": {
+            "chatgpt_account_id": account_key,
+            "user_id": account_key,
             "chatgpt_plan_type": plan
         }
     });
@@ -1186,10 +1188,10 @@ mod tests {
         }
     }
 
-    fn identity(email: &str, subject: &str) -> DisplayIdentity {
+    fn identity(email: &str, account_key: &str) -> DisplayIdentity {
         DisplayIdentity {
             email: email.to_owned(),
-            subject: Some(subject.to_owned()),
+            account_key: account_key.to_owned(),
             name: Some("Tester".to_owned()),
             plan_label: Some("Pro".to_owned()),
         }
@@ -1427,7 +1429,7 @@ mod tests {
     }
 
     #[test]
-    fn restore_verification_uses_case_insensitive_email_when_subject_missing() -> Result<()> {
+    fn restore_verification_uses_account_key_when_email_case_changes() -> Result<()> {
         let temp = tempdir()?;
         let codex_root = temp.path().join(".codex");
         fs::create_dir_all(&codex_root)?;
@@ -1445,7 +1447,7 @@ mod tests {
         let bundle = read_live_auth_bundle(&env)?;
         let expected = DisplayIdentity {
             email: "person@example.com".to_owned(),
-            subject: None,
+            account_key: bundle.identity.account_key.clone(),
             name: bundle.identity.name.clone(),
             plan_label: bundle.identity.plan_label.clone(),
         };
@@ -2393,7 +2395,7 @@ mod tests {
         };
         let expected = DisplayIdentity {
             email: "after@example.com".to_owned(),
-            subject: Some("sub-2".to_owned()),
+            account_key: "sub-2".to_owned(),
             name: Some("Tester".to_owned()),
             plan_label: Some("Plus".to_owned()),
         };
@@ -2438,7 +2440,7 @@ mod tests {
         };
         let expected = DisplayIdentity {
             email: "after@example.com".to_owned(),
-            subject: Some("sub-2".to_owned()),
+            account_key: "sub-2".to_owned(),
             name: Some("Tester".to_owned()),
             plan_label: Some("Plus".to_owned()),
         };

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -29,14 +29,23 @@ pub fn parse_identity_from_id_token(id_token: &str) -> Result<DisplayIdentity> {
         .context("failed to decode JWT payload")?;
     let claims: Value =
         serde_json::from_slice(&payload_bytes).context("failed to parse JWT payload")?;
-    let email = claims
-        .get("email")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| anyhow!("JWT payload did not contain email"))?
-        .to_owned();
-    let subject = claims.get("sub").and_then(Value::as_str).map(str::to_owned);
+    let email = string_claim(&claims, "email")
+        .or_else(|| {
+            claims
+                .get("https://api.openai.com/profile")
+                .and_then(Value::as_object)
+                .and_then(|profile| object_string_claim(profile, "email"))
+        })
+        .ok_or_else(|| anyhow!("JWT payload did not contain email"))?;
+    let auth_claims = claims
+        .get("https://api.openai.com/auth")
+        .and_then(Value::as_object);
+    let account_key = auth_claims
+        .and_then(|auth| object_string_claim(auth, "chatgpt_account_id"))
+        .or_else(|| auth_claims.and_then(|auth| object_string_claim(auth, "chatgpt_user_id")))
+        .or_else(|| auth_claims.and_then(|auth| object_string_claim(auth, "user_id")))
+        .or_else(|| string_claim(&claims, "sub"))
+        .ok_or_else(|| anyhow!("JWT payload did not contain a supported ChatGPT account id"))?;
     let name = claims
         .get("name")
         .and_then(Value::as_str)
@@ -50,11 +59,29 @@ pub fn parse_identity_from_id_token(id_token: &str) -> Result<DisplayIdentity> {
         .and_then(Value::as_str)
         .and_then(normalize_plan_label);
     Ok(DisplayIdentity {
+        account_key,
         email,
-        subject,
         name,
         plan_label,
     })
+}
+
+fn string_claim(claims: &Value, key: &str) -> Option<String> {
+    claims
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn object_string_claim(claims: &serde_json::Map<String, Value>, key: &str) -> Option<String> {
+    claims
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
 }
 
 fn normalize_plan_label(raw: &str) -> Option<String> {
@@ -102,11 +129,27 @@ mod tests {
     #[test]
     fn parses_email_and_plan() {
         let token = token(
-            r#"{"email":"person@example.com","sub":"abc","name":"Jane","https://api.openai.com/auth":{"chatgpt_plan_type":"pro_lite"}}"#,
+            r#"{"email":"person@example.com","sub":"abc","name":"Jane","https://api.openai.com/auth":{"chatgpt_account_id":"account-123","chatgpt_plan_type":"pro_lite"}}"#,
         );
         let identity = parse_identity_from_id_token(&token).expect("identity");
         assert_eq!(identity.email, "person@example.com");
-        assert_eq!(identity.subject.as_deref(), Some("abc"));
+        assert_eq!(identity.account_key, "account-123");
         assert_eq!(identity.plan_label.as_deref(), Some("Pro Lite"));
+    }
+
+    #[test]
+    fn falls_back_to_subject_when_chatgpt_account_claim_is_missing() {
+        let token = token(r#"{"email":"person@example.com","sub":"sub-123"}"#);
+        let identity = parse_identity_from_id_token(&token).expect("identity");
+
+        assert_eq!(identity.account_key, "sub-123");
+    }
+
+    #[test]
+    fn rejects_tokens_without_account_key() {
+        let token = token(r#"{"email":"person@example.com"}"#);
+        let error = parse_identity_from_id_token(&token).expect_err("identity should fail");
+
+        assert!(format!("{error:#}").contains("supported ChatGPT account id"));
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -82,7 +82,10 @@ mod tests {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SavedAccountMetadata {
     pub id: Uuid,
+    #[serde(default, deserialize_with = "optional_string")]
     pub account_key: String,
+    #[serde(default, rename = "subject", skip_serializing)]
+    pub(crate) legacy_subject: Option<String>,
     pub email: String,
     pub name: Option<String>,
     pub plan_label: Option<String>,
@@ -94,6 +97,13 @@ pub struct SavedAccountMetadata {
     pub cached_usage: Option<AccountUsageView>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cached_usage_error: Option<String>,
+}
+
+fn optional_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<String>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -41,18 +41,15 @@ pub struct SnapshotFile {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DisplayIdentity {
+    pub account_key: String,
     pub email: String,
-    pub subject: Option<String>,
     pub name: Option<String>,
     pub plan_label: Option<String>,
 }
 
 impl DisplayIdentity {
     pub fn matches(&self, other: &Self) -> bool {
-        match (&self.subject, &other.subject) {
-            (Some(left), Some(right)) => left == right,
-            _ => self.email.eq_ignore_ascii_case(&other.email),
-        }
+        self.account_key == other.account_key
     }
 }
 
@@ -60,31 +57,24 @@ impl DisplayIdentity {
 mod tests {
     use super::DisplayIdentity;
 
-    fn identity(email: &str, subject: Option<&str>) -> DisplayIdentity {
+    fn identity(email: &str, account_key: &str) -> DisplayIdentity {
         DisplayIdentity {
+            account_key: account_key.to_owned(),
             email: email.to_owned(),
-            subject: subject.map(str::to_owned),
             name: None,
             plan_label: None,
         }
     }
 
     #[test]
-    fn matches_falls_back_to_email_when_either_subject_is_missing() {
+    fn matches_uses_account_key_only() {
         assert!(
-            identity("person@example.com", Some("sub-1"))
-                .matches(&identity("PERSON@example.com", None))
+            identity("person@example.com", "account-1")
+                .matches(&identity("other@example.com", "account-1"))
         );
         assert!(
-            identity("person@example.com", None)
-                .matches(&identity("PERSON@example.com", Some("sub-1")))
-        );
-        assert!(
-            identity("person@example.com", None).matches(&identity("PERSON@example.com", None))
-        );
-        assert!(
-            !identity("person@example.com", Some("sub-1"))
-                .matches(&identity("other@example.com", None))
+            !identity("person@example.com", "account-1")
+                .matches(&identity("person@example.com", "account-2"))
         );
     }
 }
@@ -92,9 +82,8 @@ mod tests {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SavedAccountMetadata {
     pub id: Uuid,
-    pub environment: EnvironmentKind,
+    pub account_key: String,
     pub email: String,
-    pub subject: Option<String>,
     pub name: Option<String>,
     pub plan_label: Option<String>,
     pub secret_key: String,
@@ -118,11 +107,10 @@ pub struct MetadataIndex {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AccountView {
     pub id: Uuid,
+    pub account_key: String,
     pub email: String,
-    pub subject: Option<String>,
     pub name: Option<String>,
     pub plan_label: Option<String>,
-    pub environment: EnvironmentKind,
     pub is_active: bool,
     pub created_at: OffsetDateTime,
     pub updated_at: OffsetDateTime,

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -7,9 +7,7 @@ use anyhow::{Context, Result, anyhow};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
-use crate::model::{
-    AccountUsageView, DisplayIdentity, EnvironmentKind, SavedAccountMetadata, SnapshotBlob,
-};
+use crate::model::{AccountUsageView, DisplayIdentity, SavedAccountMetadata, SnapshotBlob};
 use crate::secrets::SecretStore;
 use crate::usage::usage_error_requires_login;
 use codec::{decode_snapshot, encode_snapshot};
@@ -31,35 +29,26 @@ where
         }
     }
 
-    pub fn list_accounts(
-        &self,
-        environment: &EnvironmentKind,
-    ) -> Result<Vec<SavedAccountMetadata>> {
+    pub fn list_accounts(&self) -> Result<Vec<SavedAccountMetadata>> {
         let mut accounts = self
             .index_store
             .load_index()?
             .accounts
             .into_iter()
-            .filter(|account| &account.environment == environment)
             .collect::<Vec<_>>();
         accounts.sort_by_key(|account| std::cmp::Reverse(account.updated_at));
         Ok(accounts)
     }
 
-    pub fn get_account(
-        &self,
-        environment: &EnvironmentKind,
-        account_id: Uuid,
-    ) -> Result<Option<SavedAccountMetadata>> {
+    pub fn get_account(&self, account_id: Uuid) -> Result<Option<SavedAccountMetadata>> {
         Ok(self
-            .list_accounts(environment)?
+            .list_accounts()?
             .into_iter()
             .find(|account| account.id == account_id))
     }
 
     pub fn save_snapshot(
         &self,
-        environment: &EnvironmentKind,
         identity: &DisplayIdentity,
         snapshot: &SnapshotBlob,
     ) -> Result<(SavedAccountMetadata, bool)> {
@@ -67,20 +56,19 @@ where
         let now = OffsetDateTime::now_utc();
         let encoded_snapshot = encode_snapshot(snapshot)?;
         let existing_index = index.accounts.iter().position(|account| {
-            &account.environment == environment
-                && DisplayIdentity {
-                    email: account.email.clone(),
-                    subject: account.subject.clone(),
-                    name: account.name.clone(),
-                    plan_label: account.plan_label.clone(),
-                }
-                .matches(identity)
+            DisplayIdentity {
+                account_key: account.account_key.clone(),
+                email: account.email.clone(),
+                name: account.name.clone(),
+                plan_label: account.plan_label.clone(),
+            }
+            .matches(identity)
         });
 
         let (metadata, created) = if let Some(position) = existing_index {
             let account = &mut index.accounts[position];
+            account.account_key = identity.account_key.clone();
             account.email = identity.email.clone();
-            account.subject = identity.subject.clone();
             account.name = identity.name.clone();
             account.plan_label = identity.plan_label.clone();
             account.cached_usage_error = None;
@@ -90,9 +78,8 @@ where
             let id = Uuid::new_v4();
             let metadata = SavedAccountMetadata {
                 id,
-                environment: environment.clone(),
+                account_key: identity.account_key.clone(),
                 email: identity.email.clone(),
-                subject: identity.subject.clone(),
                 name: identity.name.clone(),
                 plan_label: identity.plan_label.clone(),
                 secret_key: format!("snapshot:{id}"),
@@ -112,13 +99,9 @@ where
         Ok((metadata, created))
     }
 
-    pub fn load_snapshot(
-        &self,
-        environment: &EnvironmentKind,
-        account_id: Uuid,
-    ) -> Result<(SavedAccountMetadata, SnapshotBlob)> {
+    pub fn load_snapshot(&self, account_id: Uuid) -> Result<(SavedAccountMetadata, SnapshotBlob)> {
         let metadata = self
-            .get_account(environment, account_id)?
+            .get_account(account_id)?
             .ok_or_else(|| anyhow!("saved account {account_id} not found"))?;
         let encoded_snapshot = self
             .secret_store
@@ -135,7 +118,6 @@ where
 
     pub fn replace_snapshot(
         &self,
-        environment: &EnvironmentKind,
         account_id: Uuid,
         identity: &DisplayIdentity,
         snapshot: &SnapshotBlob,
@@ -145,12 +127,12 @@ where
         let position = index
             .accounts
             .iter()
-            .position(|account| account.id == account_id && &account.environment == environment)
+            .position(|account| account.id == account_id)
             .ok_or_else(|| anyhow!("saved account {account_id} not found"))?;
         let encoded_snapshot = encode_snapshot(snapshot)?;
         let account = &mut index.accounts[position];
+        account.account_key = identity.account_key.clone();
         account.email = identity.email.clone();
-        account.subject = identity.subject.clone();
         account.name = identity.name.clone();
         account.plan_label = identity.plan_label.clone();
         account.cached_usage = usage;
@@ -164,7 +146,6 @@ where
 
     pub fn record_usage_error(
         &self,
-        environment: &EnvironmentKind,
         account_id: Uuid,
         usage_error: String,
     ) -> Result<SavedAccountMetadata> {
@@ -172,7 +153,7 @@ where
         let position = index
             .accounts
             .iter()
-            .position(|account| account.id == account_id && &account.environment == environment)
+            .position(|account| account.id == account_id)
             .ok_or_else(|| anyhow!("saved account {account_id} not found"))?;
         let account = &mut index.accounts[position];
         if account
@@ -189,12 +170,12 @@ where
         Ok(metadata)
     }
 
-    pub fn delete_snapshot(&self, environment: &EnvironmentKind, account_id: Uuid) -> Result<()> {
+    pub fn delete_snapshot(&self, account_id: Uuid) -> Result<()> {
         let mut index = self.index_store.load_index()?;
         let Some(position) = index
             .accounts
             .iter()
-            .position(|account| account.id == account_id && &account.environment == environment)
+            .position(|account| account.id == account_id)
         else {
             return Err(anyhow!("saved account {account_id} not found"));
         };
@@ -220,7 +201,6 @@ where
 
     pub fn sync_activated_account(
         &self,
-        environment: &EnvironmentKind,
         account_id: Uuid,
         identity: &DisplayIdentity,
     ) -> Result<SavedAccountMetadata> {
@@ -229,7 +209,7 @@ where
         let Some(account_position) = index
             .accounts
             .iter()
-            .position(|account| account.id == account_id && &account.environment == environment)
+            .position(|account| account.id == account_id)
         else {
             return Err(anyhow!("saved account {account_id} not found"));
         };
@@ -239,10 +219,9 @@ where
             .enumerate()
             .filter(|(position, account)| {
                 *position != account_position
-                    && &account.environment == environment
                     && DisplayIdentity {
+                        account_key: account.account_key.clone(),
                         email: account.email.clone(),
-                        subject: account.subject.clone(),
                         name: account.name.clone(),
                         plan_label: account.plan_label.clone(),
                     }
@@ -258,11 +237,11 @@ where
         let adjusted_position = index
             .accounts
             .iter()
-            .position(|account| account.id == account_id && &account.environment == environment)
+            .position(|account| account.id == account_id)
             .ok_or_else(|| anyhow!("saved account {account_id} not found"))?;
         let account = &mut index.accounts[adjusted_position];
+        account.account_key = identity.account_key.clone();
         account.email = identity.email.clone();
-        account.subject = identity.subject.clone();
         account.name = identity.name.clone();
         account.plan_label = identity.plan_label.clone();
         account.last_activated_at = Some(now);
@@ -299,10 +278,10 @@ mod tests {
     use crate::repository::codec::SNAPSHOT_ENCODING_V1_MAGIC;
     use crate::secrets::{SecretStore, test_support::MemorySecretStore};
 
-    fn identity(email: &str, subject: &str) -> DisplayIdentity {
+    fn identity(email: &str, account_key: &str) -> DisplayIdentity {
         DisplayIdentity {
             email: email.to_owned(),
-            subject: Some(subject.to_owned()),
+            account_key: account_key.to_owned(),
             name: Some("Tester".to_owned()),
             plan_label: Some("Pro".to_owned()),
         }
@@ -323,20 +302,19 @@ mod tests {
     }
 
     #[test]
-    fn refreshes_existing_account_by_subject() {
+    fn refreshes_existing_account_by_account_key() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![],
         };
         let (first, created) = repo
-            .save_snapshot(&env, &identity("person@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("person@example.com", "sub-1"), &snapshot)
             .expect("save");
         assert!(created);
         let (second, created) = repo
-            .save_snapshot(&env, &identity("person2@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("person2@example.com", "sub-1"), &snapshot)
             .expect("save");
         assert!(!created);
         assert_eq!(first.id, second.id);
@@ -366,22 +344,21 @@ mod tests {
     fn delete_rolls_back_metadata_when_secret_delete_fails() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), FailingDeleteSecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![],
         };
         let (saved, _) = repo
-            .save_snapshot(&env, &identity("person@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("person@example.com", "sub-1"), &snapshot)
             .expect("save");
 
         let error = repo
-            .delete_snapshot(&env, saved.id)
+            .delete_snapshot(saved.id)
             .expect_err("delete should fail");
         let rendered = format!("{error:#}");
         assert!(rendered.contains("failed to delete saved snapshot data"));
         assert!(rendered.contains("delete failed"));
-        let restored = repo.get_account(&env, saved.id).expect("get account");
+        let restored = repo.get_account(saved.id).expect("get account");
         assert!(restored.is_some());
     }
 
@@ -389,20 +366,19 @@ mod tests {
     fn recovers_metadata_from_backup_when_primary_is_missing() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![],
         };
         let (saved, _) = repo
-            .save_snapshot(&env, &identity("person@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("person@example.com", "sub-1"), &snapshot)
             .expect("save");
 
         let metadata_path = temp.path().join("metadata.json");
         let backup_path = temp.path().join("metadata.json.bak-test");
         fs::rename(&metadata_path, &backup_path).expect("move backup");
 
-        let recovered = repo.get_account(&env, saved.id).expect("recover account");
+        let recovered = repo.get_account(saved.id).expect("recover account");
         assert!(recovered.is_some());
         assert!(!metadata_path.exists());
         assert!(backup_path.exists());
@@ -412,13 +388,12 @@ mod tests {
     fn recovers_newer_temp_before_older_backup() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![],
         };
         let (saved, _) = repo
-            .save_snapshot(&env, &identity("first@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("first@example.com", "sub-1"), &snapshot)
             .expect("save");
 
         let metadata_path = temp.path().join("metadata.json");
@@ -431,7 +406,7 @@ mod tests {
         fs::copy(&backup_path, &temp_path).expect("copy temp");
         rewrite_index(&temp_path, "second@example.com", now + Duration::days(1), 2);
 
-        let recovered = repo.get_account(&env, saved.id).expect("recover account");
+        let recovered = repo.get_account(saved.id).expect("recover account");
         assert_eq!(recovered.expect("account").email, "second@example.com");
         assert!(!metadata_path.exists());
         assert!(temp_path.exists());
@@ -441,13 +416,12 @@ mod tests {
     fn falls_back_to_backup_when_temp_is_invalid() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![],
         };
         let (saved, _) = repo
-            .save_snapshot(&env, &identity("first@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("first@example.com", "sub-1"), &snapshot)
             .expect("save");
 
         let metadata_path = temp.path().join("metadata.json");
@@ -455,7 +429,7 @@ mod tests {
         fs::rename(&metadata_path, &backup_path).expect("move backup");
         fs::write(temp.path().join("metadata.json.tmp-test"), "{not-json").expect("write temp");
 
-        let recovered = repo.get_account(&env, saved.id).expect("recover account");
+        let recovered = repo.get_account(saved.id).expect("recover account");
         assert_eq!(recovered.expect("account").email, "first@example.com");
     }
 
@@ -463,13 +437,12 @@ mod tests {
     fn ignores_recovery_candidates_with_unsupported_schema() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![],
         };
         let (saved, _) = repo
-            .save_snapshot(&env, &identity("first@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("first@example.com", "sub-1"), &snapshot)
             .expect("save");
 
         let metadata_path = temp.path().join("metadata.json");
@@ -484,7 +457,7 @@ mod tests {
         )
         .expect("write temp");
 
-        let recovered = repo.get_account(&env, saved.id).expect("recover account");
+        let recovered = repo.get_account(saved.id).expect("recover account");
         assert_eq!(recovered.expect("account").email, "first@example.com");
     }
 
@@ -516,11 +489,10 @@ mod tests {
     fn errors_when_canonical_metadata_is_unreadable() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
 
         fs::write(temp.path().join("metadata.json"), "{not-json").expect("write metadata");
 
-        let error = repo.list_accounts(&env).expect_err("list should fail");
+        let error = repo.list_accounts().expect_err("list should fail");
         assert!(format!("{error:#}").contains("failed to parse"));
     }
 
@@ -528,13 +500,12 @@ mod tests {
     fn recovers_newest_valid_candidate_across_temp_and_backup() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![],
         };
         let (saved, _) = repo
-            .save_snapshot(&env, &identity("first@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("first@example.com", "sub-1"), &snapshot)
             .expect("save");
 
         let metadata_path = temp.path().join("metadata.json");
@@ -551,7 +522,7 @@ mod tests {
         );
         fs::rename(&metadata_path, &backup_path).expect("move backup");
 
-        let recovered = repo.get_account(&env, saved.id).expect("recover account");
+        let recovered = repo.get_account(saved.id).expect("recover account");
         assert_eq!(recovered.expect("account").email, "first@example.com");
     }
 
@@ -559,13 +530,12 @@ mod tests {
     fn prefers_canonical_when_metadata_file_is_valid() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![],
         };
         let (saved, _) = repo
-            .save_snapshot(&env, &identity("first@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("first@example.com", "sub-1"), &snapshot)
             .expect("save");
 
         let metadata_path = temp.path().join("metadata.json");
@@ -575,7 +545,7 @@ mod tests {
         fs::copy(&metadata_path, &temp_path).expect("copy temp");
         rewrite_index(&temp_path, "second@example.com", now + Duration::days(1), 2);
 
-        let recovered = repo.get_account(&env, saved.id).expect("recover account");
+        let recovered = repo.get_account(saved.id).expect("recover account");
         assert_eq!(recovered.expect("account").email, "first@example.com");
     }
 
@@ -583,13 +553,12 @@ mod tests {
     fn prefers_pending_temp_when_it_is_newer_than_canonical() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![],
         };
         let (saved, _) = repo
-            .save_snapshot(&env, &identity("first@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("first@example.com", "sub-1"), &snapshot)
             .expect("save");
 
         let metadata_path = temp.path().join("metadata.json");
@@ -600,7 +569,7 @@ mod tests {
         rewrite_index(&temp_path, "second@example.com", now + Duration::days(1), 2);
         fs::copy(&temp_path, temp.path().join("metadata.json.pending")).expect("write pending");
 
-        let recovered = repo.get_account(&env, saved.id).expect("recover account");
+        let recovered = repo.get_account(saved.id).expect("recover account");
         assert_eq!(recovered.expect("account").email, "second@example.com");
     }
 
@@ -608,13 +577,12 @@ mod tests {
     fn successful_save_cleans_up_its_recovery_artifacts() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![],
         };
 
-        repo.save_snapshot(&env, &identity("person@example.com", "sub-1"), &snapshot)
+        repo.save_snapshot(&identity("person@example.com", "sub-1"), &snapshot)
             .expect("save");
 
         let entries = fs::read_dir(temp.path())
@@ -638,13 +606,12 @@ mod tests {
     fn falls_back_to_valid_recovery_when_canonical_is_corrupt() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![],
         };
         let (saved, _) = repo
-            .save_snapshot(&env, &identity("person@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("person@example.com", "sub-1"), &snapshot)
             .expect("save");
 
         let metadata_path = temp.path().join("metadata.json");
@@ -652,7 +619,7 @@ mod tests {
         fs::copy(&metadata_path, &backup_path).expect("copy backup");
         fs::write(&metadata_path, "{not-json").expect("corrupt canonical");
 
-        let recovered = repo.get_account(&env, saved.id).expect("recover account");
+        let recovered = repo.get_account(saved.id).expect("recover account");
         assert!(recovered.is_some());
     }
 
@@ -660,36 +627,26 @@ mod tests {
     fn activation_sync_removes_duplicate_identity_rows() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![],
         };
 
         let first = repo
-            .save_snapshot(
-                &env,
-                &DisplayIdentity {
-                    email: "legacy@example.com".to_owned(),
-                    subject: None,
-                    name: Some("Tester".to_owned()),
-                    plan_label: Some("Pro".to_owned()),
-                },
-                &snapshot,
-            )
+            .save_snapshot(&identity("stale@example.com", "stale-key"), &snapshot)
             .expect("save first")
             .0;
         let duplicate = repo
-            .save_snapshot(&env, &identity("current@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("current@example.com", "sub-1"), &snapshot)
             .expect("save duplicate")
             .0;
 
         let updated = repo
-            .sync_activated_account(&env, first.id, &identity("current@example.com", "sub-1"))
+            .sync_activated_account(first.id, &identity("current@example.com", "sub-1"))
             .expect("sync");
         assert_eq!(updated.email, "current@example.com");
 
-        let accounts = repo.list_accounts(&env).expect("list");
+        let accounts = repo.list_accounts().expect("list");
         assert_eq!(accounts.len(), 1);
         assert_eq!(accounts[0].id, first.id);
         assert!(
@@ -704,36 +661,26 @@ mod tests {
     fn activation_sync_succeeds_when_duplicate_secret_cleanup_fails() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), FailingDeleteSecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![],
         };
 
         let first = repo
-            .save_snapshot(
-                &env,
-                &DisplayIdentity {
-                    email: "legacy@example.com".to_owned(),
-                    subject: None,
-                    name: Some("Tester".to_owned()),
-                    plan_label: Some("Pro".to_owned()),
-                },
-                &snapshot,
-            )
+            .save_snapshot(&identity("stale@example.com", "stale-key"), &snapshot)
             .expect("save first")
             .0;
         let duplicate = repo
-            .save_snapshot(&env, &identity("current@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("current@example.com", "sub-1"), &snapshot)
             .expect("save duplicate")
             .0;
 
         let updated = repo
-            .sync_activated_account(&env, first.id, &identity("current@example.com", "sub-1"))
+            .sync_activated_account(first.id, &identity("current@example.com", "sub-1"))
             .expect("sync");
         assert_eq!(updated.email, "current@example.com");
 
-        let accounts = repo.list_accounts(&env).expect("list");
+        let accounts = repo.list_accounts().expect("list");
         assert_eq!(accounts.len(), 1);
         assert_eq!(accounts[0].id, first.id);
         assert!(
@@ -748,7 +695,6 @@ mod tests {
     fn save_snapshot_stores_compressed_payload_and_loads_it_back() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![
@@ -764,7 +710,7 @@ mod tests {
         };
 
         let (saved, _) = repo
-            .save_snapshot(&env, &identity("person@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("person@example.com", "sub-1"), &snapshot)
             .expect("save");
         let raw = repo
             .secret_store
@@ -773,7 +719,7 @@ mod tests {
             .expect("stored payload");
         assert!(raw.starts_with(SNAPSHOT_ENCODING_V1_MAGIC));
 
-        let loaded = repo.load_snapshot(&env, saved.id).expect("load snapshot").1;
+        let loaded = repo.load_snapshot(saved.id).expect("load snapshot").1;
         assert_eq!(loaded.schema_version, snapshot.schema_version);
         assert_eq!(loaded.files.len(), snapshot.files.len());
         assert_eq!(loaded.files[0].bytes_base64, "auth-payload");
@@ -784,20 +730,19 @@ mod tests {
     fn usage_error_is_persisted_and_cleared_by_snapshot_refresh() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![],
         };
         let saved = repo
-            .save_snapshot(&env, &identity("person@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("person@example.com", "sub-1"), &snapshot)
             .expect("save")
             .0;
 
-        repo.record_usage_error(&env, saved.id, "Login required".to_owned())
+        repo.record_usage_error(saved.id, "Login required".to_owned())
             .expect("record error");
         assert_eq!(
-            repo.get_account(&env, saved.id)
+            repo.get_account(saved.id)
                 .expect("get")
                 .expect("account")
                 .cached_usage_error
@@ -806,7 +751,6 @@ mod tests {
         );
 
         repo.replace_snapshot(
-            &env,
             saved.id,
             &identity("person@example.com", "sub-1"),
             &snapshot,
@@ -815,7 +759,7 @@ mod tests {
         .expect("replace");
 
         assert!(
-            repo.get_account(&env, saved.id)
+            repo.get_account(saved.id)
                 .expect("get")
                 .expect("account")
                 .cached_usage_error
@@ -827,27 +771,25 @@ mod tests {
     fn transient_usage_error_does_not_replace_login_required_marker() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![],
         };
         let saved = repo
-            .save_snapshot(&env, &identity("person@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("person@example.com", "sub-1"), &snapshot)
             .expect("save")
             .0;
 
-        repo.record_usage_error(&env, saved.id, "Login required".to_owned())
+        repo.record_usage_error(saved.id, "Login required".to_owned())
             .expect("record login error");
         repo.record_usage_error(
-            &env,
             saved.id,
             "Usage unavailable: failed to query Codex usage".to_owned(),
         )
         .expect("record transient error");
 
         assert_eq!(
-            repo.get_account(&env, saved.id)
+            repo.get_account(saved.id)
                 .expect("get")
                 .expect("account")
                 .cached_usage_error
@@ -857,34 +799,33 @@ mod tests {
     }
 
     #[test]
-    fn load_snapshot_accepts_legacy_plain_json_payloads() {
+    fn load_snapshot_rejects_plain_json_payloads() {
         let temp = tempdir().expect("tempdir");
         let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
-        let env = EnvironmentKind::Windows;
         let snapshot = SnapshotBlob {
             schema_version: 1,
             files: vec![
                 crate::model::SnapshotFile {
                     name: "auth.json".to_owned(),
-                    bytes_base64: "legacy-auth".to_owned(),
+                    bytes_base64: "plain-json-auth".to_owned(),
                 },
                 crate::model::SnapshotFile {
                     name: "cap_sid".to_owned(),
-                    bytes_base64: "legacy-cap".to_owned(),
+                    bytes_base64: "plain-json-cap".to_owned(),
                 },
             ],
         };
         let (saved, _) = repo
-            .save_snapshot(&env, &identity("person@example.com", "sub-1"), &snapshot)
+            .save_snapshot(&identity("person@example.com", "sub-1"), &snapshot)
             .expect("save");
-        let legacy = serde_json::to_vec(&snapshot).expect("serialize legacy");
+        let plain_json = serde_json::to_vec(&snapshot).expect("serialize plain JSON");
         repo.secret_store
-            .save(&saved.secret_key, &legacy)
-            .expect("overwrite with legacy payload");
+            .save(&saved.secret_key, &plain_json)
+            .expect("overwrite with plain JSON payload");
 
-        let loaded = repo.load_snapshot(&env, saved.id).expect("load snapshot").1;
-        assert_eq!(loaded.schema_version, snapshot.schema_version);
-        assert_eq!(loaded.files[0].bytes_base64, "legacy-auth");
-        assert_eq!(loaded.files[1].bytes_base64, "legacy-cap");
+        let error = repo
+            .load_snapshot(saved.id)
+            .expect_err("plain JSON payload should be rejected");
+        assert!(format!("{error:#}").contains("unsupported stored snapshot encoding"));
     }
 }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result, anyhow};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
+use crate::codex;
 use crate::model::{AccountUsageView, DisplayIdentity, SavedAccountMetadata, SnapshotBlob};
 use crate::secrets::SecretStore;
 use crate::usage::usage_error_requires_login;
@@ -30,12 +31,7 @@ where
     }
 
     pub fn list_accounts(&self) -> Result<Vec<SavedAccountMetadata>> {
-        let mut accounts = self
-            .index_store
-            .load_index()?
-            .accounts
-            .into_iter()
-            .collect::<Vec<_>>();
+        let mut accounts = self.load_index()?.accounts;
         accounts.sort_by_key(|account| std::cmp::Reverse(account.updated_at));
         Ok(accounts)
     }
@@ -52,7 +48,7 @@ where
         identity: &DisplayIdentity,
         snapshot: &SnapshotBlob,
     ) -> Result<(SavedAccountMetadata, bool)> {
-        let mut index = self.index_store.load_index()?;
+        let mut index = self.load_index()?;
         let now = OffsetDateTime::now_utc();
         let encoded_snapshot = encode_snapshot(snapshot)?;
         let existing_index = index.accounts.iter().position(|account| {
@@ -79,6 +75,7 @@ where
             let metadata = SavedAccountMetadata {
                 id,
                 account_key: identity.account_key.clone(),
+                legacy_subject: None,
                 email: identity.email.clone(),
                 name: identity.name.clone(),
                 plan_label: identity.plan_label.clone(),
@@ -123,7 +120,7 @@ where
         snapshot: &SnapshotBlob,
         usage: Option<AccountUsageView>,
     ) -> Result<SavedAccountMetadata> {
-        let mut index = self.index_store.load_index()?;
+        let mut index = self.load_index()?;
         let position = index
             .accounts
             .iter()
@@ -149,7 +146,7 @@ where
         account_id: Uuid,
         usage_error: String,
     ) -> Result<SavedAccountMetadata> {
-        let mut index = self.index_store.load_index()?;
+        let mut index = self.load_index()?;
         let position = index
             .accounts
             .iter()
@@ -171,7 +168,7 @@ where
     }
 
     pub fn delete_snapshot(&self, account_id: Uuid) -> Result<()> {
-        let mut index = self.index_store.load_index()?;
+        let mut index = self.load_index()?;
         let Some(position) = index
             .accounts
             .iter()
@@ -204,7 +201,7 @@ where
         account_id: Uuid,
         identity: &DisplayIdentity,
     ) -> Result<SavedAccountMetadata> {
-        let mut index = self.index_store.load_index()?;
+        let mut index = self.load_index()?;
         let now = OffsetDateTime::now_utc();
         let Some(account_position) = index
             .accounts
@@ -253,6 +250,39 @@ where
         }
         Ok(updated)
     }
+
+    fn load_index(&self) -> Result<crate::model::MetadataIndex> {
+        let mut index = self.index_store.load_index()?;
+        let mut changed = false;
+        for account in &mut index.accounts {
+            if account.account_key.trim().is_empty()
+                || account.legacy_subject.as_deref().is_some_and(|subject| {
+                    !subject.trim().is_empty() && subject != account.account_key
+                })
+            {
+                if let Some(identity) = self.identity_for_account(account) {
+                    account.account_key = identity.account_key;
+                } else if let Some(subject) = account.legacy_subject.as_deref() {
+                    account.account_key = subject.to_owned();
+                } else if account.account_key.trim().is_empty() {
+                    // ponytail: old subjectless rows stay listable/deletable; snapshot refresh supplies the real key.
+                    account.account_key = format!("legacy:{}", account.id);
+                }
+                account.legacy_subject = None;
+                changed = true;
+            }
+        }
+        if changed {
+            self.index_store.save_index(&index)?;
+        }
+        Ok(index)
+    }
+
+    fn identity_for_account(&self, account: &SavedAccountMetadata) -> Option<DisplayIdentity> {
+        let encoded_snapshot = self.secret_store.load(&account.secret_key).ok().flatten()?;
+        let snapshot = decode_snapshot(&encoded_snapshot).ok()?;
+        codex::identity_from_snapshot(&snapshot).ok()
+    }
 }
 
 #[cfg(test)]
@@ -270,6 +300,8 @@ mod tests {
     use std::fs;
 
     use anyhow::{Result, anyhow};
+    use base64::Engine;
+    use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
     use tempfile::tempdir;
     use time::Duration;
 
@@ -284,6 +316,42 @@ mod tests {
             account_key: account_key.to_owned(),
             name: Some("Tester".to_owned()),
             plan_label: Some("Pro".to_owned()),
+        }
+    }
+
+    fn snapshot_with_auth(email: &str, subject: &str, account_key: &str) -> SnapshotBlob {
+        let payload = serde_json::json!({
+            "email": email,
+            "sub": subject,
+            "name": "Tester",
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": account_key,
+                "chatgpt_plan_type": "pro"
+            }
+        });
+        let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"none"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(payload.to_string());
+        let auth_json = serde_json::json!({
+            "tokens": {
+                "id_token": format!("{header}.{payload}."),
+                "access_token": "access",
+                "refresh_token": "refresh",
+                "account_id": "acct"
+            },
+            "auth_mode": "chatgpt"
+        });
+        SnapshotBlob {
+            schema_version: 1,
+            files: vec![
+                crate::model::SnapshotFile {
+                    name: "auth.json".to_owned(),
+                    bytes_base64: STANDARD.encode(auth_json.to_string()),
+                },
+                crate::model::SnapshotFile {
+                    name: "cap_sid".to_owned(),
+                    bytes_base64: STANDARD.encode("sid"),
+                },
+            ],
         }
     }
 
@@ -319,6 +387,76 @@ mod tests {
         assert!(!created);
         assert_eq!(first.id, second.id);
         assert_eq!(second.email, "person2@example.com");
+    }
+
+    #[test]
+    fn loads_legacy_subject_metadata_without_account_key() {
+        let temp = tempdir().expect("tempdir");
+        let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
+        let snapshot = SnapshotBlob {
+            schema_version: 1,
+            files: vec![],
+        };
+        let (subject_row, _) = repo
+            .save_snapshot(
+                &identity("subject@example.com", "account-1"),
+                &snapshot_with_auth("subject@example.com", "sub-1", "account-1"),
+            )
+            .expect("save subject row");
+        let (subjectless_row, _) = repo
+            .save_snapshot(&identity("subjectless@example.com", "sub-2"), &snapshot)
+            .expect("save subjectless row");
+        let (corrupt_row, _) = repo
+            .save_snapshot(&identity("corrupt@example.com", "sub-3"), &snapshot)
+            .expect("save corrupt row");
+        let metadata_path = temp.path().join("metadata.json");
+        let mut raw: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&metadata_path).expect("read metadata"))
+                .expect("parse metadata");
+        for account in raw["accounts"].as_array_mut().expect("accounts") {
+            let account = account.as_object_mut().expect("account");
+            let account_key = account.remove("account_key").expect("account key");
+            account.insert("environment".to_owned(), serde_json::json!("windows"));
+            account.insert(
+                "subject".to_owned(),
+                if account["id"] == subject_row.id.to_string() {
+                    account_key
+                } else if account["id"] == corrupt_row.id.to_string() {
+                    serde_json::json!("sub-3")
+                } else {
+                    serde_json::Value::Null
+                },
+            );
+        }
+        repo.secret_store
+            .save(&corrupt_row.secret_key, b"not-a-snapshot")
+            .expect("corrupt saved snapshot");
+        fs::write(
+            &metadata_path,
+            serde_json::to_string_pretty(&raw).expect("serialize legacy metadata"),
+        )
+        .expect("write legacy metadata");
+
+        let loaded = repo.list_accounts().expect("list legacy metadata");
+        let subject_account = loaded
+            .iter()
+            .find(|account| account.id == subject_row.id)
+            .expect("subject account");
+        let subjectless_account = loaded
+            .iter()
+            .find(|account| account.id == subjectless_row.id)
+            .expect("subjectless account");
+        let corrupt_account = loaded
+            .iter()
+            .find(|account| account.id == corrupt_row.id)
+            .expect("corrupt account");
+
+        assert_eq!(subject_account.account_key, "account-1");
+        assert_eq!(
+            subjectless_account.account_key,
+            format!("legacy:{}", subjectless_row.id)
+        );
+        assert_eq!(corrupt_account.account_key, "sub-3");
     }
 
     #[derive(Clone, Default)]

--- a/src/repository/codec.rs
+++ b/src/repository/codec.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Write};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
@@ -23,14 +23,13 @@ pub(super) fn encode_snapshot(snapshot: &SnapshotBlob) -> Result<Vec<u8>> {
 }
 
 pub(super) fn decode_snapshot(encoded: &[u8]) -> Result<SnapshotBlob> {
-    if let Some(compressed) = encoded.strip_prefix(SNAPSHOT_ENCODING_V1_MAGIC) {
-        let mut decoder = GzDecoder::new(compressed);
-        let mut serialized = Vec::new();
-        decoder
-            .read_to_end(&mut serialized)
-            .context("failed to decompress stored snapshot")?;
-        return serde_json::from_slice(&serialized).context("failed to parse stored snapshot");
-    }
-
-    serde_json::from_slice(encoded).context("failed to parse stored snapshot")
+    let Some(compressed) = encoded.strip_prefix(SNAPSHOT_ENCODING_V1_MAGIC) else {
+        bail!("unsupported stored snapshot encoding; re-save that account");
+    };
+    let mut decoder = GzDecoder::new(compressed);
+    let mut serialized = Vec::new();
+    decoder
+        .read_to_end(&mut serialized)
+        .context("failed to decompress stored snapshot")?;
+    serde_json::from_slice(&serialized).context("failed to parse stored snapshot")
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -17,11 +17,6 @@ pub trait SecretStore {
     fn delete(&self, key: &str) -> Result<()>;
 }
 
-trait LegacySnapshotStore {
-    fn load_legacy(&self, key: &str) -> Result<Option<Vec<u8>>>;
-    fn delete_legacy(&self, key: &str) -> Result<()>;
-}
-
 #[derive(Clone, Debug)]
 pub struct LocalSecretStore {
     root_dir: PathBuf,
@@ -159,72 +154,6 @@ impl SecretStore for LocalSecretStore {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct MigratingSecretStore<L> {
-    local: LocalSecretStore,
-    legacy: L,
-}
-
-impl<L> MigratingSecretStore<L> {
-    #[cfg(test)]
-    pub fn with_legacy(root_dir: &Path, legacy: L) -> Self {
-        Self {
-            local: LocalSecretStore::new(root_dir),
-            legacy,
-        }
-    }
-}
-
-impl MigratingSecretStore<DefaultLegacyStore> {
-    pub fn new(root_dir: &Path) -> Self {
-        Self {
-            local: LocalSecretStore::new(root_dir),
-            legacy: DefaultLegacyStore::default(),
-        }
-    }
-}
-
-impl<L> SecretStore for MigratingSecretStore<L>
-where
-    L: LegacySnapshotStore,
-{
-    fn save(&self, key: &str, value: &[u8]) -> Result<()> {
-        self.local.save(key, value)?;
-        let _ = self.legacy.delete_legacy(key);
-        Ok(())
-    }
-
-    fn load(&self, key: &str) -> Result<Option<Vec<u8>>> {
-        let local_result = self.local.load(key);
-        match local_result {
-            Ok(Some(value)) => return Ok(Some(value)),
-            Ok(None) => {}
-            Err(local_error) => {
-                if let Some(legacy_value) = self.legacy.load_legacy(key)? {
-                    if self.local.save(key, &legacy_value).is_ok() {
-                        let _ = self.legacy.delete_legacy(key);
-                    }
-                    return Ok(Some(legacy_value));
-                }
-                return Err(local_error);
-            }
-        }
-
-        let Some(legacy_value) = self.legacy.load_legacy(key)? else {
-            return Ok(None);
-        };
-        if self.local.save(key, &legacy_value).is_ok() {
-            let _ = self.legacy.delete_legacy(key);
-        }
-        Ok(Some(legacy_value))
-    }
-
-    fn delete(&self, key: &str) -> Result<()> {
-        self.legacy.delete_legacy(key)?;
-        self.local.delete(key)
-    }
-}
-
 fn ensure_store_dir(root_dir: &Path) -> Result<()> {
     if root_dir.exists() {
         set_private_dir_permissions(root_dir)?;
@@ -294,77 +223,21 @@ fn set_private_dir_permissions(path: &Path) -> Result<()> {
 }
 
 fn snapshot_payload_is_valid(value: &[u8]) -> bool {
-    if let Some(compressed) = value.strip_prefix(SNAPSHOT_ENCODING_V1_MAGIC) {
-        let mut decoder = GzDecoder::new(compressed);
-        let mut decoded = Vec::new();
-        if std::io::Read::read_to_end(&mut decoder, &mut decoded).is_err() {
-            return false;
-        }
-        return serde_json::from_slice::<SnapshotBlob>(&decoded).is_ok();
+    let Some(compressed) = value.strip_prefix(SNAPSHOT_ENCODING_V1_MAGIC) else {
+        return false;
+    };
+    let mut decoder = GzDecoder::new(compressed);
+    let mut decoded = Vec::new();
+    if std::io::Read::read_to_end(&mut decoder, &mut decoded).is_err() {
+        return false;
     }
-
-    serde_json::from_slice::<SnapshotBlob>(value).is_ok()
+    serde_json::from_slice::<SnapshotBlob>(&decoded).is_ok()
 }
 
 fn file_mtime(path: &Path) -> Option<SystemTime> {
     fs::metadata(path)
         .and_then(|metadata| metadata.modified())
         .ok()
-}
-
-#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
-type DefaultLegacyStore = KeyringLegacyStore;
-#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-type DefaultLegacyStore = NoopLegacyStore;
-
-#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
-#[derive(Clone, Debug)]
-pub struct KeyringLegacyStore {
-    service_name: &'static str,
-}
-
-#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
-impl Default for KeyringLegacyStore {
-    fn default() -> Self {
-        Self {
-            service_name: "codex-account-switcher",
-        }
-    }
-}
-
-#[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
-impl LegacySnapshotStore for KeyringLegacyStore {
-    fn load_legacy(&self, key: &str) -> Result<Option<Vec<u8>>> {
-        let entry = keyring::Entry::new(self.service_name, key)?;
-        match entry.get_password() {
-            Ok(value) => Ok(Some(value.into_bytes())),
-            Err(keyring::Error::NoEntry) => Ok(None),
-            Err(error) => Err(error).context("failed to load legacy snapshot from keychain"),
-        }
-    }
-
-    fn delete_legacy(&self, key: &str) -> Result<()> {
-        let entry = keyring::Entry::new(self.service_name, key)?;
-        match entry.delete_credential() {
-            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
-            Err(error) => Err(error).context("failed to delete legacy snapshot from keychain"),
-        }
-    }
-}
-
-#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-#[derive(Clone, Debug, Default)]
-pub struct NoopLegacyStore;
-
-#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-impl LegacySnapshotStore for NoopLegacyStore {
-    fn load_legacy(&self, _key: &str) -> Result<Option<Vec<u8>>> {
-        Ok(None)
-    }
-
-    fn delete_legacy(&self, _key: &str) -> Result<()> {
-        Ok(())
-    }
 }
 
 #[cfg(test)]
@@ -403,70 +276,21 @@ pub mod test_support {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use std::fs;
-    use std::sync::{Arc, Mutex};
+    use std::io::Write;
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
 
-    use anyhow::Result;
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
     use tempfile::tempdir;
 
-    use super::{LegacySnapshotStore, LocalSecretStore, MigratingSecretStore, SecretStore};
+    use super::{LocalSecretStore, SNAPSHOT_ENCODING_V1_MAGIC, SecretStore};
     use crate::model::{SnapshotBlob, SnapshotFile};
 
-    #[derive(Clone, Default)]
-    struct FakeLegacyStore {
-        inner: Arc<Mutex<HashMap<String, Vec<u8>>>>,
-    }
-
-    impl FakeLegacyStore {
-        fn insert(&self, key: &str, value: &[u8]) {
-            self.inner
-                .lock()
-                .expect("lock")
-                .insert(key.to_owned(), value.to_vec());
-        }
-    }
-
-    impl LegacySnapshotStore for FakeLegacyStore {
-        fn load_legacy(&self, key: &str) -> Result<Option<Vec<u8>>> {
-            Ok(self.inner.lock().expect("lock").get(key).cloned())
-        }
-
-        fn delete_legacy(&self, key: &str) -> Result<()> {
-            self.inner.lock().expect("lock").remove(key);
-            Ok(())
-        }
-    }
-
-    #[derive(Clone, Default)]
-    struct FailingDeleteLegacyStore {
-        inner: Arc<Mutex<HashMap<String, Vec<u8>>>>,
-    }
-
-    impl FailingDeleteLegacyStore {
-        fn insert(&self, key: &str, value: &[u8]) {
-            self.inner
-                .lock()
-                .expect("lock")
-                .insert(key.to_owned(), value.to_vec());
-        }
-    }
-
-    impl LegacySnapshotStore for FailingDeleteLegacyStore {
-        fn load_legacy(&self, key: &str) -> Result<Option<Vec<u8>>> {
-            Ok(self.inner.lock().expect("lock").get(key).cloned())
-        }
-
-        fn delete_legacy(&self, _key: &str) -> Result<()> {
-            Err(anyhow::anyhow!("legacy delete failed"))
-        }
-    }
-
     fn valid_snapshot_bytes() -> Vec<u8> {
-        serde_json::to_vec(&SnapshotBlob {
+        encoded_snapshot(SnapshotBlob {
             schema_version: 1,
             files: vec![
                 SnapshotFile {
@@ -479,11 +303,10 @@ mod tests {
                 },
             ],
         })
-        .expect("snapshot")
     }
 
     fn updated_snapshot_bytes() -> Vec<u8> {
-        serde_json::to_vec(&SnapshotBlob {
+        encoded_snapshot(SnapshotBlob {
             schema_version: 1,
             files: vec![
                 SnapshotFile {
@@ -496,7 +319,15 @@ mod tests {
                 },
             ],
         })
-        .expect("snapshot")
+    }
+
+    fn encoded_snapshot(snapshot: SnapshotBlob) -> Vec<u8> {
+        let serialized = serde_json::to_vec(&snapshot).expect("snapshot");
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&serialized).expect("compress snapshot");
+        let mut encoded = SNAPSHOT_ENCODING_V1_MAGIC.to_vec();
+        encoded.extend(encoder.finish().expect("finish compression"));
+        encoded
     }
 
     #[test]
@@ -700,77 +531,6 @@ mod tests {
         assert!(format!("{error:#}").contains("failed to delete snapshot"));
 
         assert!(!temp.path().join("c25hcHNob3Q6dGVzdA.snapshot").exists());
-    }
-
-    #[test]
-    fn migrating_store_moves_legacy_payload_into_local_storage() {
-        let temp = tempdir().expect("tempdir");
-        let legacy = FakeLegacyStore::default();
-        let payload = valid_snapshot_bytes();
-        legacy.insert("snapshot:test", &payload);
-        let store = MigratingSecretStore::with_legacy(temp.path(), legacy.clone());
-
-        let loaded = store.load("snapshot:test").expect("load").expect("payload");
-        assert_eq!(loaded, payload);
-        assert!(
-            temp.path().join("c25hcHNob3Q6dGVzdA.snapshot").exists(),
-            "payload should be migrated into local storage"
-        );
-        assert!(
-            legacy
-                .load_legacy("snapshot:test")
-                .expect("legacy load")
-                .is_none(),
-            "legacy payload should be cleaned up after migration"
-        );
-    }
-
-    #[test]
-    fn migrating_store_save_cleans_up_legacy_copy() {
-        let temp = tempdir().expect("tempdir");
-        let legacy = FakeLegacyStore::default();
-        let payload = valid_snapshot_bytes();
-        legacy.insert("snapshot:test", &payload);
-        let store = MigratingSecretStore::with_legacy(temp.path(), legacy.clone());
-
-        store.save("snapshot:test", &payload).expect("save");
-        assert!(
-            legacy
-                .load_legacy("snapshot:test")
-                .expect("legacy load")
-                .is_none(),
-            "save should clear the stale legacy copy"
-        );
-    }
-
-    #[test]
-    fn migrating_store_falls_back_to_legacy_when_local_load_errors() {
-        let temp = tempdir().expect("tempdir");
-        fs::create_dir(temp.path().join("c25hcHNob3Q6dGVzdA.snapshot"))
-            .expect("create unreadable canonical directory");
-        let legacy = FakeLegacyStore::default();
-        let payload = valid_snapshot_bytes();
-        legacy.insert("snapshot:test", &payload);
-        let store = MigratingSecretStore::with_legacy(temp.path(), legacy);
-
-        let loaded = store.load("snapshot:test").expect("load").expect("payload");
-        assert_eq!(loaded, payload);
-    }
-
-    #[test]
-    fn migrating_store_delete_surfaces_legacy_cleanup_failures() {
-        let temp = tempdir().expect("tempdir");
-        let legacy = FailingDeleteLegacyStore::default();
-        let payload = valid_snapshot_bytes();
-        legacy.insert("snapshot:test", &payload);
-        let store = MigratingSecretStore::with_legacy(temp.path(), legacy);
-        store.save("snapshot:test", &payload).expect("save");
-
-        let error = store
-            .delete("snapshot:test")
-            .expect_err("delete should fail");
-        assert!(format!("{error:#}").contains("legacy delete failed"));
-        assert!(temp.path().join("c25hcHNob3Q6dGVzdA.snapshot").exists());
     }
 
     #[cfg(unix)]

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -336,10 +336,7 @@ fn find_active_tray_account<'a>(
 }
 
 fn account_matches_identity(account: &AccountView, identity: &DisplayIdentity) -> bool {
-    match (&account.subject, &identity.subject) {
-        (Some(left), Some(right)) => left == right,
-        _ => account.email.eq_ignore_ascii_case(&identity.email),
-    }
+    account.account_key == identity.account_key
 }
 
 fn tray_row_label<const N: usize>(
@@ -540,7 +537,7 @@ fn fallback_icon() -> Icon {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{AccountUsageView, EnvironmentKind, UsageSource, UsageWindowView};
+    use crate::model::{AccountUsageView, UsageSource, UsageWindowView};
     use time::{Date, Month, OffsetDateTime, Time};
 
     #[test]
@@ -551,10 +548,9 @@ mod tests {
         let mut account = AccountView {
             id: Uuid::new_v4(),
             email: "person@example.com".to_owned(),
-            subject: Some("sub".to_owned()),
+            account_key: "sub".to_owned(),
             name: None,
             plan_label: Some("Pro".to_owned()),
-            environment: EnvironmentKind::Windows,
             is_active: true,
             created_at: OffsetDateTime::UNIX_EPOCH,
             updated_at: OffsetDateTime::UNIX_EPOCH,
@@ -589,10 +585,9 @@ mod tests {
         let account = AccountView {
             id: Uuid::new_v4(),
             email: "person@example.com".to_owned(),
-            subject: Some("sub".to_owned()),
+            account_key: "sub".to_owned(),
             name: None,
             plan_label: Some("Pro".to_owned()),
-            environment: EnvironmentKind::Windows,
             is_active: false,
             created_at: OffsetDateTime::UNIX_EPOCH,
             updated_at: OffsetDateTime::UNIX_EPOCH,
@@ -632,10 +627,9 @@ mod tests {
         let active = AccountView {
             id: Uuid::new_v4(),
             email: "active@example.com".to_owned(),
-            subject: Some("sub".to_owned()),
+            account_key: "sub".to_owned(),
             name: None,
             plan_label: Some("Pro".to_owned()),
-            environment: EnvironmentKind::Windows,
             is_active: true,
             created_at: OffsetDateTime::UNIX_EPOCH,
             updated_at: OffsetDateTime::UNIX_EPOCH,
@@ -663,10 +657,9 @@ mod tests {
         let account = AccountView {
             id: Uuid::new_v4(),
             email: "active@example.com".to_owned(),
-            subject: Some("sub".to_owned()),
+            account_key: "sub".to_owned(),
             name: None,
             plan_label: Some("Pro".to_owned()),
-            environment: EnvironmentKind::Windows,
             is_active: true,
             created_at: OffsetDateTime::UNIX_EPOCH,
             updated_at: OffsetDateTime::UNIX_EPOCH,
@@ -676,13 +669,13 @@ mod tests {
         };
         let matching_identity = DisplayIdentity {
             email: "active@example.com".to_owned(),
-            subject: Some("sub".to_owned()),
+            account_key: "sub".to_owned(),
             name: None,
             plan_label: Some("Pro".to_owned()),
         };
         let mismatched_identity = DisplayIdentity {
             email: "other@example.com".to_owned(),
-            subject: Some("other-sub".to_owned()),
+            account_key: "other-sub".to_owned(),
             name: None,
             plan_label: Some("Pro".to_owned()),
         };
@@ -700,10 +693,9 @@ mod tests {
         let mut saved_account = AccountView {
             id: Uuid::new_v4(),
             email: "stale@example.com".to_owned(),
-            subject: Some("sub".to_owned()),
+            account_key: "sub".to_owned(),
             name: None,
             plan_label: Some("Pro".to_owned()),
-            environment: EnvironmentKind::Windows,
             is_active: true,
             created_at: OffsetDateTime::UNIX_EPOCH,
             updated_at: OffsetDateTime::UNIX_EPOCH,
@@ -724,7 +716,7 @@ mod tests {
         });
         let account = DisplayIdentity {
             email: "person@example.com".to_owned(),
-            subject: None,
+            account_key: "sub".to_owned(),
             name: None,
             plan_label: Some("ProLite".to_owned()),
         };
@@ -745,7 +737,7 @@ mod tests {
     fn active_account_label_marks_unsaved_current_account() {
         let account = DisplayIdentity {
             email: "person@example.com".to_owned(),
-            subject: None,
+            account_key: "sub".to_owned(),
             name: None,
             plan_label: Some("Plus".to_owned()),
         };

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -50,7 +50,7 @@ pub fn fetch_usage(target: UsageTarget) -> Result<(UsageOutput, SnapshotBlob)> {
         target.snapshot
     };
 
-    let fetched_identity = merge_identity(&target.identity, response.identity()?);
+    let fetched_identity = response.merged_identity(&target.identity);
     Ok((
         UsageOutput {
             environment: target.environment,
@@ -164,16 +164,14 @@ struct ErrorResponse {
 }
 
 impl UsageResponse {
-    fn identity(&self) -> Result<Option<DisplayIdentity>> {
-        let Some(email) = &self.email else {
-            return Ok(None);
-        };
-        Ok(Some(DisplayIdentity {
-            email: email.clone(),
-            subject: None,
-            name: None,
-            plan_label: normalize_plan_label(self.plan_type.as_deref()),
-        }))
+    fn merged_identity(&self, base: &DisplayIdentity) -> DisplayIdentity {
+        DisplayIdentity {
+            account_key: base.account_key.clone(),
+            email: self.email.clone().unwrap_or_else(|| base.email.clone()),
+            name: base.name.clone(),
+            plan_label: normalize_plan_label(self.plan_type.as_deref())
+                .or_else(|| base.plan_label.clone()),
+        }
     }
 
     fn into_view(self, source: UsageSource) -> Result<AccountUsageView> {
@@ -374,18 +372,6 @@ fn normalize_plan_label(raw: Option<&str>) -> Option<String> {
         "pro" => Some("Pro".to_owned()),
         "free" => Some("Free".to_owned()),
         other => Some(other.to_owned()),
-    }
-}
-
-fn merge_identity(base: &DisplayIdentity, fetched: Option<DisplayIdentity>) -> DisplayIdentity {
-    let Some(fetched) = fetched else {
-        return base.clone();
-    };
-    DisplayIdentity {
-        email: fetched.email,
-        subject: base.subject.clone(),
-        name: base.name.clone(),
-        plan_label: fetched.plan_label.or_else(|| base.plan_label.clone()),
     }
 }
 


### PR DESCRIPTION
## Summary

- Save account identity as one required `account_key` parsed from current ChatGPT/OAuth claims, with JWT `sub` only as a parser fallback.
- Remove per-account environment fields and repository environment filtering; the app-data directory remains the environment boundary.
- Remove keyring migration and raw JSON snapshot compatibility so saved snapshots use the local compressed store format only.

## Validation

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- Review Suite emergency: `rvw_159da700` clean
