### PR TITLE
[codex] speed up interactive startup refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ codex-account-switcher auto-start-usage-windows [--enable|--disable] [--run] [--
 - `usage` fetches current usage for the live account or for a saved account by id.
 - `activate` restores a saved snapshot. Reliable swaps require all Codex processes to be closed first; `--force` lets the command attempt activation anyway, but it still fails if the restored files do not stay stable.
 - `delete` removes the saved snapshot from the switcher store only.
-- `auto-start-usage-windows` is opt-in from the CLI, TUI, or tray checkmark. When enabled, the interactive app refreshes saved weekly windows every 5 minutes and starts due windows with a minimal `codex exec` ping when Codex is on `PATH`.
+- `auto-start-usage-windows` is opt-in from the CLI, TUI, or tray checkmark. When enabled, the interactive app checks saved weekly windows every 5 minutes and starts due or freshly reset windows with a minimal `codex exec` ping when Codex is on `PATH`.
 
 Saved snapshot data lives in the app-data directory for the current environment:
 

--- a/src/app/auto_start.rs
+++ b/src/app/auto_start.rs
@@ -83,6 +83,9 @@ where
         let now = OffsetDateTime::now_utc();
         let mut due_accounts = Vec::new();
         for account in &accounts {
+            if !auto_start_check_needs_usage_refresh(account, now) {
+                continue;
+            }
             let cached_weekly = cached_weekly_window(account);
             let cached_due = cached_weekly.is_some_and(|weekly| weekly.reset_at <= now);
             let previous_reset_at = cached_weekly.map(|weekly| weekly.reset_at);
@@ -263,6 +266,23 @@ fn cached_weekly_window(account: &SavedAccountMetadata) -> Option<&UsageWindowVi
         return None;
     }
     account.cached_usage.as_ref()?.weekly.as_ref()
+}
+
+fn auto_start_check_needs_usage_refresh(
+    account: &SavedAccountMetadata,
+    now: OffsetDateTime,
+) -> bool {
+    if let Some(error) = account.cached_usage_error.as_deref() {
+        return !usage_error_requires_login(error);
+    }
+    match account
+        .cached_usage
+        .as_ref()
+        .and_then(|usage| usage.weekly.as_ref())
+    {
+        Some(weekly) => weekly.reset_at <= now || weekly.remaining_percent == 100,
+        None => true,
+    }
 }
 
 fn auto_start_check_usage_cache(
@@ -599,11 +619,18 @@ mod tests {
     }
 
     fn weekly_usage(reset_at: OffsetDateTime) -> AccountUsageView {
+        weekly_usage_with_remaining(reset_at, 100)
+    }
+
+    fn weekly_usage_with_remaining(
+        reset_at: OffsetDateTime,
+        remaining_percent: u8,
+    ) -> AccountUsageView {
         AccountUsageView {
             source: UsageSource::SavedAccessToken,
             fetched_at: OffsetDateTime::UNIX_EPOCH,
             five_hour: None,
-            weekly: Some(weekly_window(reset_at, 100)),
+            weekly: Some(weekly_window(reset_at, remaining_percent)),
             credits: None,
         }
     }
@@ -691,6 +718,45 @@ mod tests {
         );
 
         assert!(cached_weekly_window(&account).is_none());
+    }
+
+    #[test]
+    fn auto_start_usage_refresh_prefilter_keeps_only_possible_ping_candidates() {
+        let now = OffsetDateTime::now_utc();
+
+        assert!(!auto_start_check_needs_usage_refresh(
+            &saved_account(
+                Some(weekly_usage_with_remaining(now + Duration::days(1), 99)),
+                None
+            ),
+            now
+        ));
+        assert!(auto_start_check_needs_usage_refresh(
+            &saved_account(Some(weekly_usage(now - Duration::minutes(1))), None),
+            now
+        ));
+        assert!(auto_start_check_needs_usage_refresh(
+            &saved_account(Some(weekly_usage(now + Duration::days(7))), None),
+            now
+        ));
+        assert!(auto_start_check_needs_usage_refresh(
+            &saved_account(None, Some("Usage unavailable: timeout".to_owned())),
+            now
+        ));
+        assert!(auto_start_check_needs_usage_refresh(
+            &saved_account(
+                Some(weekly_usage_with_remaining(now + Duration::days(1), 99)),
+                Some("Usage unavailable: timeout".to_owned())
+            ),
+            now
+        ));
+        assert!(!auto_start_check_needs_usage_refresh(
+            &saved_account(
+                Some(weekly_usage(now - Duration::minutes(1))),
+                Some("Login required: Codex auth expired.".to_owned())
+            ),
+            now
+        ));
     }
 
     #[test]

--- a/src/app/service.rs
+++ b/src/app/service.rs
@@ -150,11 +150,41 @@ where
         crate::process::detect_running_codex_processes()
     }
 
-    pub fn refresh_saved_usage_cache(&self) -> Result<()> {
+    pub(crate) fn refresh_saved_usage_cache(&self) -> Result<()> {
         let accounts = self.repository.list_accounts()?;
         for account in accounts {
-            let _ = self.usage(Some(account.id));
+            let _ = self.refresh_saved_usage_cache_account(account.id);
         }
+        Ok(())
+    }
+
+    fn refresh_saved_usage_cache_account(&self, account_id: Uuid) -> Result<()> {
+        let (snapshot, _, _) = self.load_activation_target(account_id)?;
+        let target = usage_target_from_snapshot(
+            self.env.kind.clone(),
+            snapshot.clone(),
+            UsageSource::SavedAccessToken,
+            true,
+        )?;
+        let result = fetch_usage(target);
+        let (output, refreshed_snapshot) = match result {
+            Ok(result) => result,
+            Err(error) => {
+                let _ = self.repository.record_usage_error_if_current(
+                    account_id,
+                    &snapshot,
+                    usage_error_message(&error),
+                );
+                return Err(error);
+            }
+        };
+        self.repository.replace_snapshot_if_current(
+            account_id,
+            &snapshot,
+            &output.account,
+            &refreshed_snapshot,
+            Some(output.usage),
+        )?;
         Ok(())
     }
 

--- a/src/app/tui.rs
+++ b/src/app/tui.rs
@@ -25,13 +25,6 @@ where
         force_running: bool,
     ) -> Result<InteractiveExit> {
         let mut default_selection = 0usize;
-        if matches!(mode, InteractiveMode::Persistent) {
-            if self.auto_start_usage_windows_status()?.enabled {
-                let _ = self.auto_start_usage_windows_once(true)?;
-            } else {
-                self.refresh_saved_usage_cache()?;
-            }
-        }
         let mut feedback = Vec::new();
         loop {
             let status = self.status()?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -218,6 +218,9 @@ where
     S: crate::secrets::SecretStore,
 {
     crate::app::spawn_auto_start_usage_windows_worker(app.env().clone());
+    if !app.auto_start_usage_windows_status()?.enabled {
+        spawn_saved_usage_cache_refresh(app.env().clone());
+    }
     #[cfg(windows)]
     {
         loop {
@@ -239,6 +242,28 @@ where
             InteractiveExit::Quit => Ok(()),
         }
     }
+}
+
+fn spawn_saved_usage_cache_refresh(env: env::AppEnv) {
+    static STARTED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    STARTED.get_or_init(move || {
+        let _ = std::thread::Builder::new()
+            .name("saved-usage-cache-refresh".to_owned())
+            .spawn(move || {
+                if let Err(error) = run_saved_usage_cache_refresh(env) {
+                    eprintln!("saved usage refresh failed: {error:#}");
+                }
+            });
+    });
+}
+
+fn run_saved_usage_cache_refresh(env: env::AppEnv) -> Result<()> {
+    let repository = SnapshotRepository::new(
+        &env.app_data_dir,
+        LocalSecretStore::new(&env.app_data_dir.join("snapshots")),
+    );
+    let app = App::new(env, repository);
+    app.refresh_saved_usage_cache()
 }
 
 fn print_json<T>(value: &T) -> Result<()>

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::{Mutex, MutexGuard};
 
 mod codec;
 mod index_store;
@@ -13,6 +14,8 @@ use crate::secrets::SecretStore;
 use crate::usage::usage_error_requires_login;
 use codec::{decode_snapshot, encode_snapshot};
 use index_store::MetadataIndexStore;
+
+static REPOSITORY_WRITE_LOCK: Mutex<()> = Mutex::new(());
 
 pub struct SnapshotRepository<S> {
     index_store: MetadataIndexStore,
@@ -31,14 +34,24 @@ where
     }
 
     pub fn list_accounts(&self) -> Result<Vec<SavedAccountMetadata>> {
+        let _guard = repository_write_lock()?;
+        self.list_accounts_unlocked()
+    }
+
+    fn list_accounts_unlocked(&self) -> Result<Vec<SavedAccountMetadata>> {
         let mut accounts = self.load_index()?.accounts;
         accounts.sort_by_key(|account| std::cmp::Reverse(account.updated_at));
         Ok(accounts)
     }
 
     pub fn get_account(&self, account_id: Uuid) -> Result<Option<SavedAccountMetadata>> {
+        let _guard = repository_write_lock()?;
+        self.get_account_unlocked(account_id)
+    }
+
+    fn get_account_unlocked(&self, account_id: Uuid) -> Result<Option<SavedAccountMetadata>> {
         Ok(self
-            .list_accounts()?
+            .list_accounts_unlocked()?
             .into_iter()
             .find(|account| account.id == account_id))
     }
@@ -48,6 +61,7 @@ where
         identity: &DisplayIdentity,
         snapshot: &SnapshotBlob,
     ) -> Result<(SavedAccountMetadata, bool)> {
+        let _guard = repository_write_lock()?;
         let mut index = self.load_index()?;
         let now = OffsetDateTime::now_utc();
         let encoded_snapshot = encode_snapshot(snapshot)?;
@@ -97,8 +111,16 @@ where
     }
 
     pub fn load_snapshot(&self, account_id: Uuid) -> Result<(SavedAccountMetadata, SnapshotBlob)> {
+        let _guard = repository_write_lock()?;
+        self.load_snapshot_unlocked(account_id)
+    }
+
+    fn load_snapshot_unlocked(
+        &self,
+        account_id: Uuid,
+    ) -> Result<(SavedAccountMetadata, SnapshotBlob)> {
         let metadata = self
-            .get_account(account_id)?
+            .get_account_unlocked(account_id)?
             .ok_or_else(|| anyhow!("saved account {account_id} not found"))?;
         let encoded_snapshot = self
             .secret_store
@@ -114,6 +136,34 @@ where
     }
 
     pub fn replace_snapshot(
+        &self,
+        account_id: Uuid,
+        identity: &DisplayIdentity,
+        snapshot: &SnapshotBlob,
+        usage: Option<AccountUsageView>,
+    ) -> Result<SavedAccountMetadata> {
+        let _guard = repository_write_lock()?;
+        self.replace_snapshot_unlocked(account_id, identity, snapshot, usage)
+    }
+
+    pub fn replace_snapshot_if_current(
+        &self,
+        account_id: Uuid,
+        expected_snapshot: &SnapshotBlob,
+        identity: &DisplayIdentity,
+        snapshot: &SnapshotBlob,
+        usage: Option<AccountUsageView>,
+    ) -> Result<bool> {
+        let _guard = repository_write_lock()?;
+        let (_, current_snapshot) = self.load_snapshot_unlocked(account_id)?;
+        if current_snapshot != *expected_snapshot {
+            return Ok(false);
+        }
+        self.replace_snapshot_unlocked(account_id, identity, snapshot, usage)?;
+        Ok(true)
+    }
+
+    fn replace_snapshot_unlocked(
         &self,
         account_id: Uuid,
         identity: &DisplayIdentity,
@@ -146,6 +196,30 @@ where
         account_id: Uuid,
         usage_error: String,
     ) -> Result<SavedAccountMetadata> {
+        let _guard = repository_write_lock()?;
+        self.record_usage_error_unlocked(account_id, usage_error)
+    }
+
+    pub fn record_usage_error_if_current(
+        &self,
+        account_id: Uuid,
+        expected_snapshot: &SnapshotBlob,
+        usage_error: String,
+    ) -> Result<bool> {
+        let _guard = repository_write_lock()?;
+        let (_, current_snapshot) = self.load_snapshot_unlocked(account_id)?;
+        if current_snapshot != *expected_snapshot {
+            return Ok(false);
+        }
+        self.record_usage_error_unlocked(account_id, usage_error)?;
+        Ok(true)
+    }
+
+    fn record_usage_error_unlocked(
+        &self,
+        account_id: Uuid,
+        usage_error: String,
+    ) -> Result<SavedAccountMetadata> {
         let mut index = self.load_index()?;
         let position = index
             .accounts
@@ -168,6 +242,7 @@ where
     }
 
     pub fn delete_snapshot(&self, account_id: Uuid) -> Result<()> {
+        let _guard = repository_write_lock()?;
         let mut index = self.load_index()?;
         let Some(position) = index
             .accounts
@@ -201,6 +276,7 @@ where
         account_id: Uuid,
         identity: &DisplayIdentity,
     ) -> Result<SavedAccountMetadata> {
+        let _guard = repository_write_lock()?;
         let mut index = self.load_index()?;
         let now = OffsetDateTime::now_utc();
         let Some(account_position) = index
@@ -283,6 +359,12 @@ where
         let snapshot = decode_snapshot(&encoded_snapshot).ok()?;
         codex::identity_from_snapshot(&snapshot).ok()
     }
+}
+
+fn repository_write_lock() -> Result<MutexGuard<'static, ()>> {
+    REPOSITORY_WRITE_LOCK
+        .lock()
+        .map_err(|_| anyhow!("snapshot repository write lock poisoned"))
 }
 
 #[cfg(test)]
@@ -903,6 +985,56 @@ mod tests {
                 .cached_usage_error
                 .is_none()
         );
+    }
+
+    #[test]
+    fn conditional_snapshot_writes_skip_when_snapshot_changed() {
+        let temp = tempdir().expect("tempdir");
+        let repo = SnapshotRepository::new(temp.path(), MemorySecretStore::default());
+        let first_identity = identity("first@example.com", "sub-1");
+        let first_snapshot = snapshot_with_auth("first@example.com", "subject-1", "sub-1");
+        let second_identity = identity("second@example.com", "sub-2");
+        let second_snapshot = snapshot_with_auth("second@example.com", "subject-2", "sub-2");
+        let saved = repo
+            .save_snapshot(&first_identity, &first_snapshot)
+            .expect("save")
+            .0;
+
+        assert!(
+            repo.replace_snapshot_if_current(
+                saved.id,
+                &first_snapshot,
+                &second_identity,
+                &second_snapshot,
+                None,
+            )
+            .expect("conditional replace")
+        );
+        assert!(
+            !repo
+                .replace_snapshot_if_current(
+                    saved.id,
+                    &first_snapshot,
+                    &first_identity,
+                    &first_snapshot,
+                    None,
+                )
+                .expect("stale conditional replace")
+        );
+        assert!(
+            !repo
+                .record_usage_error_if_current(
+                    saved.id,
+                    &first_snapshot,
+                    "Usage unavailable".to_owned(),
+                )
+                .expect("stale conditional error")
+        );
+
+        let (loaded, loaded_snapshot) = repo.load_snapshot(saved.id).expect("load");
+        assert_eq!(loaded.email, "second@example.com");
+        assert_eq!(loaded_snapshot, second_snapshot);
+        assert!(loaded.cached_usage_error.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remove the blocking usage refresh from the TUI startup path so the first menu renders from cached account data
- keep usage windows fresh in the background, with auto-start prefiltering accounts that cannot need a ping yet
- serialize repository snapshot writes and make background refresh writes conditional so account switches cannot be overwritten by stale refreshes

## Validation
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build --release --target-dir target\fast-startup-check
- review-suite normal: local signoff clean